### PR TITLE
Add instructions for updating NuGet packages

### DIFF
--- a/Part 2 - Project Creation/README.md
+++ b/Part 2 - Project Creation/README.md
@@ -1,6 +1,6 @@
 # Create a new project using the AI Web Chat template
 
-> **⏱️ Estimated Time:** 30-45 minutes
+> **⏱️ Estimated Time:** 35-50 minutes
 
 ## In this workshop
 
@@ -85,6 +85,53 @@ If you prefer to use the command line, you can create the same project using the
    start GenAiLab.sln  # For Visual Studio
    ```
 
+## Update NuGet packages
+
+Due to recent updates in .NET Aspire 9.4 and dependency changes in AI packages, you need to update all NuGet packages in the solution to their latest versions (including prerelease packages) before running the application:
+
+### Using Visual Studio
+
+1. In the Solution Explorer, right-click on the solution file (`GenAiLab.sln`) and select "Manage NuGet Packages for Solution..."
+
+   ![Manage NuGet Packages for Solution](../images/manage-nuget-solution.png)
+
+1. In the NuGet Package Manager, click on the "Updates" tab
+
+1. Check the "Include prerelease" checkbox to include preview versions of AI packages
+
+1. Click "Update All" to update all packages to their latest versions
+
+   ![Update All Prerelease Packages](../images/update-all-prerelease.png)
+
+1. Review and accept any license agreements that appear
+
+1. Wait for all packages to be updated and restored
+
+### Using the .NET CLI
+
+If you prefer to use the command line, you can update all packages using the NuGet CLI:
+
+1. Navigate to the solution directory (if not already there):
+
+   ```powershell
+   cd GenAiLab
+   ```
+
+2. Update all packages in the solution, including prerelease versions:
+
+   ```powershell
+   nuget update GenAiLab.sln -Prerelease
+   ```
+
+   > **Note**: This command requires the NuGet CLI to be installed. If you don't have it installed, you can install it via `dotnet tool install --global NuGet.CommandLine` or use the Visual Studio method above.
+
+3. After the update completes, restore and build the solution to ensure everything is working:
+
+   ```powershell
+   dotnet restore
+   dotnet build
+   ```
+
 ## Set the GitHub Models connection string
 
 For GitHub Models to work, you need to set up a connection string with a GitHub token:
@@ -165,6 +212,7 @@ Let's test the AI functionality of the application:
 ## What You've Learned
 
 - How to create a new project using the AI Web Chat template in Visual Studio
+- How to update NuGet packages in a solution to get the latest AI and Aspire components
 - How to configure GitHub Models as the AI service provider
 - How to set up the connection string for AI services
 - How to use .NET Aspire to orchestrate multiple services

--- a/Part 2 - Project Creation/README.md
+++ b/Part 2 - Project Creation/README.md
@@ -109,23 +109,27 @@ Due to recent updates in .NET Aspire 9.4 and dependency changes in AI packages, 
 
 ### Using the .NET CLI
 
-If you prefer to use the command line, you can update all packages using the NuGet CLI:
+If you prefer to use the command line, you can update all packages using the `dotnet outdated` tool:
 
-1. Navigate to the solution directory (if not already there):
+1. First, install the `dotnet outdated` global tool if you haven't already:
+
+   ```powershell
+   dotnet tool install --global dotnet-outdated-tool
+   ```
+
+2. Navigate to the solution directory (if not already there):
 
    ```powershell
    cd GenAiLab
    ```
 
-2. Update all packages in the solution, including prerelease versions:
+3. Update all packages in the solution, including prerelease versions:
 
    ```powershell
-   nuget update GenAiLab.sln -Prerelease
+   dotnet outdated --solution GenAiLab.sln --upgrade --pre-release Always
    ```
 
-   > **Note**: This command requires the NuGet CLI to be installed. If you don't have it installed, you can install it via `dotnet tool install --global NuGet.CommandLine` or use the Visual Studio method above.
-
-3. After the update completes, restore and build the solution to ensure everything is working:
+4. After the update completes, restore and build the solution to ensure everything is working:
 
    ```powershell
    dotnet restore


### PR DESCRIPTION
This pull request updates the `Part 2 - Project Creation/README.md` file with revised time estimates and instructions for updating NuGet packages. It also adds a new learning objective related to updating packages. The most important changes are as follows:

### Documentation Updates:

* Updated the estimated time for project creation from "30-45 minutes" to "35-50 minutes" to reflect more accurate expectations. (`[Part 2 - Project Creation/README.mdL3-R3](diffhunk://#diff-61c084074a9b8dc8eda4b499f1aa909b6624d3ace6fea9631462b64817aca39fL3-R3)`)

* Added detailed instructions for updating NuGet packages to the latest versions, including prerelease packages, using both Visual Studio and the .NET CLI. This ensures compatibility with recent updates in .NET Aspire 9.4 and AI packages. (`[Part 2 - Project Creation/README.mdR88-R134](diffhunk://#diff-61c084074a9b8dc8eda4b499f1aa909b6624d3ace6fea9631462b64817aca39fR88-R134)`)

### Learning Objectives:

* Added a new learning objective about updating NuGet packages to the latest AI and Aspire components. (`[Part 2 - Project Creation/README.mdR215](diffhunk://#diff-61c084074a9b8dc8eda4b499f1aa909b6624d3ace6fea9631462b64817aca39fR215)`)