### PR TITLE
Cleanup: package alignment, skill fix, and Azure AI Search optional step

### DIFF
--- a/.github/skills/workshop-testing/SKILL.md
+++ b/.github/skills/workshop-testing/SKILL.md
@@ -84,6 +84,6 @@ Write `docs/testing/workshop-test-report-<YYYY-MM-DD>.md` using [report-template
 ## Known quirks
 
 - Package versions drift between parts (`Microsoft.Extensions.AI`, `Microsoft.Agents.AI`, `Azure.AI.OpenAI`). Flag inconsistencies in the report rather than unilaterally bumping them.
-- The MCP template's namespace style has changed between previews; the Part 6 snapshot uses `namespace MyMcpServer.Tools;` while Part 7's tool file has none. Note which style the current template emits.
+- The MCP template's namespace style has changed between previews; the Part 6 snapshot uses `namespace ContosoOrdersMcpServer.Tools;` while Part 7's tool file has none. Note which style the current template emits.
 - Missing `--vector-store qdrant` in Part 4 silently produces a local JSON store app that no longer matches the Part 11 snapshot.
 - The AI Web Chat template ships `ChatInput.razor.js` and `ChatMessageList.razor.js` (auto-resize and auto-scroll). They must survive into any snapshot update.

--- a/Part 02 - Build Chat App/ChatApp/ChatApp.csproj
+++ b/Part 02 - Build Chat App/ChatApp/ChatApp.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.3.0-beta.2" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.1" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />

--- a/Part 03 - Add RAG/RagChatApp/RagChatApp.csproj
+++ b/Part 03 - Add RAG/RagChatApp/RagChatApp.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.3.0-beta.2" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.1" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />

--- a/Part 03 - Add RAG/checkpoints/verify/ManualCheckpoint/ManualCheckpoint.csproj
+++ b/Part 03 - Add RAG/checkpoints/verify/ManualCheckpoint/ManualCheckpoint.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.3.0-beta.2" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.1" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />

--- a/Part 03 - Add RAG/checkpoints/verify/MediCheckpoint/MediCheckpoint.csproj
+++ b/Part 03 - Add RAG/checkpoints/verify/MediCheckpoint/MediCheckpoint.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.3.0-beta.2" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.1" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />

--- a/Part 08 - Agent Framework Basics/AgentApp/AgentApp.csproj
+++ b/Part 08 - Agent Framework Basics/AgentApp/AgentApp.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.3.0-beta.2" />
     <PackageReference Include="Microsoft.Agents.AI" Version="1.15.0" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.1" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.1" />

--- a/Part 09 - Adding AI to an Existing App/eShopLite/Products/Products.csproj
+++ b/Part 09 - Adding AI to an Existing App/eShopLite/Products/Products.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.3.0-beta.2" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.1" />

--- a/Part 09 - Adding AI to an Existing App/eShopLite/Store/Store.csproj
+++ b/Part 09 - Adding AI to an Existing App/eShopLite/Store/Store.csproj
@@ -6,7 +6,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.3.0-beta.2" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.1" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.1" />
   </ItemGroup>

--- a/Part 10 - Choosing Providers and Services/README.md
+++ b/Part 10 - Choosing Providers and Services/README.md
@@ -168,6 +168,51 @@ the swap is a registration change in two files rather than a rewrite — see
 [Optional: using a managed vector store](../Part%2011%20-%20Deployment/README.md#optional-using-a-managed-vector-store)
 in the next part.
 
+## Optional: set up Azure AI Search for deployment
+
+If you plan to take the managed vector store path in Part 11, provision the
+service now so the deployment unit is pure deployment. You will use the AI Web
+Chat project from [Part 4](../Part%2004%20-%20AI%20Web%20Chat%20Template/README.md)
+— if you do not have it, scaffold a fresh one in about a minute:
+
+```bash
+dotnet new aichatweb --provider azureopenai --vector-store local --name ProviderTest --output ProviderTest
+```
+
+1. **Create the Azure AI Search service** in the Azure portal: **Create a
+   resource → Azure AI Search**. Vector search requires the **Basic** tier or
+   higher — the Free tier does not support it.
+2. **Capture the credentials**: from the service's **Keys** blade, note the
+   endpoint URL (`https://<name>.search.windows.net`) and an admin key. The
+   connection string format the deployment expects is:
+
+   ```text
+   Endpoint=https://<name>.search.windows.net;Key=<admin-key>
+   ```
+
+3. **See what changes in the app**: scaffold the Part 4 template a second time
+   with the Azure AI Search vector store and diff it against your project:
+
+   ```bash
+   dotnet new aichatweb --provider azureopenai --vector-store azureaisearch --aspire --name GenAiLabSearch --output GenAiLabSearch
+   ```
+
+   The differences are confined to registration: the `AddQdrantClient` /
+   `AddQdrantCollection<...>` calls in `Program.cs` and the
+   `builder.AddQdrant("vectordb")` resource in `AppHost.cs`. Your search and
+   ingestion code (`SemanticSearch`, `DataIngestor`) is written against
+   `VectorStoreCollection<TKey, TRecord>` and does not change.
+4. **Deploy with Part 11's steps.** When `azd provision` prompts for the search
+   infrastructure parameter, paste the connection string from step 2.
+5. **Tear down when finished** — `azd down --purge --force`, and confirm the
+   Search service is gone in the portal. Azure AI Search is billed per service
+   hour even when idle, unlike the Qdrant container.
+
+> [!NOTE]
+> If you scaffolded the Docker-free `--vector-store local` project in the
+> morning, this swap is also your upgrade path from the local JSON store to a
+> real vector database.
+
 ## What's next
 
 You have made the two decisions that deployment depends on: which provider serves

--- a/Part 11 - Deployment/README.md
+++ b/Part 11 - Deployment/README.md
@@ -188,7 +188,11 @@ Rather than editing by hand, scaffold the template a second time with the Azure 
 Search vector store option (the same `dotnet new aichatweb` command from
 [Part 4](../Part%2004%20-%20AI%20Web%20Chat%20Template/README.md), with a different
 `--vector-store` value) and diff the two projects. That shows you the exact
-registration and Aspire wiring the template generates.
+registration and Aspire wiring the template generates. For the provisioning
+steps — creating the Search service and the connection string to give `azd` —
+see
+[Optional: set up Azure AI Search for deployment](../Part%2010%20-%20Choosing%20Providers%20and%20Services/README.md#optional-set-up-azure-ai-search-for-deployment)
+in Part 10.
 
 The trade-off is the usual one. Qdrant is cheaper and portable, and you own the
 container and its data volume. Azure AI Search is billed per service hour even


### PR DESCRIPTION
## Summary

Three small cleanups on one branch:

1. **Fix workshop-testing skill quirk** — the known-quirks list said the Part 6 snapshot uses `namespace MyMcpServer.Tools;`; it actually uses `namespace ContosoOrdersMcpServer.Tools;`.
2. **Align `Azure.AI.OpenAI` package versions** — bump ChatApp, RagChatApp, AgentApp, and StoreApp from 2.1.0 to 2.3.0-beta.2 so all snapshots match GenAiLab.Web (Part 11). The dotnet-build CI matrix validates the build.
3. **Restore the optional Azure AI Search walkthrough** — the step-by-step managed-vector-store instructions (originally in the pre-renumber `Part 6 - Deployment` README) were removed in #553, leaving only a "scaffold and diff" note. This adds them back as an optional applied section in **Part 10 - Choosing Providers and Services** (where provider/service selection happens, immediately before deployment), with a cross-link from Part 11's "Optional: using a managed vector store" section. Includes the scaffold escape hatch for attendees without their Part 4 project, the Basic-tier requirement, the `Endpoint=...;Key=...` connection-string format for the `azd provision` prompt, and a mandatory teardown warning (AI Search bills per service hour when idle).

## Needs verification

The `--vector-store azureaisearch` template flag and the `azd` `azureAISearch` infrastructure-parameter prompt are restored from the pre-#553 content and should be validated against the current `Microsoft.Extensions.AI.Templates` aichatweb template in a workshop-testing run before the next delivery.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
