### PR TITLE
Refactor Copilot repository instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,67 +1,33 @@
 # .NET AI Workshop
 
-Teaching repository for a one-day .NET AI workshop. Content is **11 self-contained parts**, each a top-level `Part NN - <Name>/` folder containing a `README.md` (the lab instructions) and, where applicable, a working code snapshot. Folder names are zero-padded so they sort correctly in the GitHub web UI; prose and headings use the unpadded "Part N" form.
+Teaching repository for a one-day, 11-part .NET AI workshop. The active workshop
+content is in zero-padded `Part NN - <Name>/` folders; prose and headings use the
+unpadded "Part N" form. Some parts deliberately continue work from earlier parts.
 
-Everything targets **.NET 10** and uses **Microsoft Foundry (Azure OpenAI)** as the default provider.
+Everything targets **.NET 10** and uses **Microsoft Foundry (Azure OpenAI)** as the
+default provider.
 
-## Parts and code snapshots
+## Repository invariants
 
-| Part | Snapshot project | Notes |
-| --- | --- | --- |
-| 01 - Setup | — | README only |
-| 02 - Build Chat App | `ChatApp/` | Console app built by hand (`dotnet new console`) |
-| 03 - Add RAG | `RagChatApp/` | Continues from Part 2; `checkpoints/` holds two alternate `Program.cs` paths (manual cosine similarity, and MEDI + SqliteVec). `checkpoints/verify/` holds compile-only projects so CI type-checks both checkpoints — the snapshot itself is the Step 2 manual path |
-| 04 - AI Web Chat Template | *(continues into `Part 11 - Deployment/GenAiLab/`)* | README only in this folder; scaffolds the Qdrant-based `GenAiLab` with `dotnet new aichatweb` |
-| 05 - MCP Server Basics | `MyMcpServer/` | `dotnet new mcpserver` (template from `Microsoft.McpServer.ProjectTemplates`); `RandomNumberTools` + `WeatherTools` |
-| 06 - Enhanced MCP Server | `ContosoOrdersMcpServer/` | Optional/bonus. Exploration of an existing snapshot — the README does **not** ask the user to scaffold it |
-| 07 - MCP Publishing | — | Optional/bonus, README only |
-| 08 - Agent Framework Basics | `AgentApp/` | `dotnet new console` + `Microsoft.Agents.AI` |
-| 09 - Adding AI to an Existing App | `eShopLite-start/` and `eShopLite/` (5-project Aspire solutions) | Capstone. `eShopLite-start/` is the AI-free starting point attendees work in; `eShopLite/` is the finished answer key. The workshop adds semantic search, grounded discovery, and a local-model assistant. Added code lives in `Products/Ai/` and `Store/Ai/` |
-| 10 - Choosing Providers and Services | — | Applied deployment preparation. Replaces Qdrant with Azure AI Search on the recommended path; retaining Qdrant is the fallback |
-| 11 - Deployment | `GenAiLab/` (3-project Aspire solution) | Deployment-ready continuation of Part 4 with Azure AI Search and `WithExternalHttpEndpoints()` |
+- Treat the root `README.md` as the workshop catalog and pacing authority.
+- Keep attendee instructions and their committed code snapshots in sync.
+- Scaffold projects with `dotnet new`; do not hand-author project files that the
+  workshop teaches attendees to generate.
+- Never commit secrets or generated output such as `bin/`, `obj/`, `.vs/`, or
+  `.azure/`.
+- Preserve a zero-warning build. Use `.github/workflows/dotnet-build.yml` as the
+  authority for the current build matrix and SDK version.
+- Use `.github/workflows/markdownlint.yml` and `.github/workflows/link-check.yml`
+  as the authorities for documentation validation.
 
-Other folders: `docs/` (instructor guides, planning, archived test reports), `images/` (screenshots used by workshop instructions), `manuals/` (PDFs used as RAG source data).
+## Working in this repository
 
-## Build
-
-CI (`.github/workflows/dotnet-build.yml`) restores and builds these nine targets on the .NET `10.0.x` SDK with `--configuration Release`. Run the same set when validating a change:
-
-```pwsh
-"Part 02 - Build Chat App/ChatApp/ChatApp.csproj",
-"Part 03 - Add RAG/RagChatApp/RagChatApp.csproj",
-"Part 03 - Add RAG/checkpoints/verify/Checkpoints.slnx",
-"Part 05 - MCP Server Basics/MyMcpServer/MyMcpServer.csproj",
-"Part 06 - Enhanced MCP Server/ContosoOrdersMcpServer/ContosoOrdersMcpServer.csproj",
-"Part 08 - Agent Framework Basics/AgentApp/AgentApp.csproj",
-"Part 09 - Adding AI to an Existing App/eShopLite/eShopLite.slnx",
-"Part 09 - Adding AI to an Existing App/eShopLite-start/eShopLite.slnx",
-"Part 11 - Deployment/GenAiLab/GenAiLab.sln" | ForEach-Object { dotnet build $_ -c Release }
-```
-
-All nine targets build clean — zero warnings. Treat any new warning as a regression.
-
-Markdown is linted by `.github/workflows/markdownlint.yml` using `.markdownlint.json`.
-
-## Conventions
-
-- **Snapshots must match the README.** If you change instructions in a `README.md`, update that part's snapshot code in the same change, and vice versa.
-- **Projects are created with `dotnet new`,** never by hand-authoring a `.csproj`. Templates come from `Microsoft.Extensions.AI.Templates`, `Microsoft.McpServer.ProjectTemplates`, and `Aspire.ProjectTemplates`.
-- **Scaffold, then update packages.** Templates lag the current package versions. After `dotnet new`, bump to current and record the bump as an explicit README step so the snapshot and the instructions stay in sync. Part 9 is pinned at Aspire **13.4.6**; the shared Parts 4 and 11 `GenAiLab` app is pinned at **13.5.3**. Note that the `<Sdk Name="Aspire.AppHost.Sdk" />` element must be edited by hand because `dotnet add package` only manages `<PackageReference>` items.
-- The Part 4 scaffold command is fixed and load-bearing for later parts:
-  `dotnet new aichatweb --provider azureopenai --vector-store qdrant --aspire --name GenAiLab --output GenAiLab`
-  (a Docker-free variant, `--vector-store local --managed-identity false`, is documented as an alternative).
-- **The AppHost deliberately diverges from the template.** The template scaffolds `builder.AddAzureOpenAI("openai")` plus `AddDeployment` calls, which makes Aspire try to *provision* an Azure OpenAI account and blocks on a tenant/subscription prompt. Setting `ConnectionStrings:openai` does not suppress it. Parts 4 and 11 replace that block with `builder.AddConnectionString("openai")` and teach the swap as an explicit step. See `docs/instructor/AICHATWEB_TEMPLATE_NOTES.md`.
-- Console samples (Parts 2, 3, 8) read credentials from **user secrets**: `AzureOpenAI:Endpoint` and `AzureOpenAI:Key`. Part 9 sets the same two secrets in both its `Products` and `Store` projects, plus optional `LocalModel:Endpoint` / `LocalModel:Model` in `Store` for its Foundry Local step. Part 11 uses the Aspire connection string `ConnectionStrings:openai`.
-- Never commit secrets. `.azure/` is gitignored, and `azure.yaml` is generated by `azd init` at deploy time rather than checked in.
-- Don't commit `bin/`, `obj/`, or `.vs/` into snapshots.
-- Docker/Podman is needed for Part 4's Qdrant path and the markitdown container. Part 9 is Aspire but deliberately container-free — it uses SQLite and `SqliteVec`.
-
-## Testing the workshop end to end
-
-Use the **workshop-testing** skill (`.github/skills/workshop-testing/`) when asked to walk through the workshop as an attendee, validate a part, or reconcile snapshots against the READMEs.
-
-Credentials for testing come from `.github/scripts/setup-workshop-credentials.ps1`, which sets `WORKSHOP_AZURE_OPENAI_ENDPOINT`, `WORKSHOP_AZURE_OPENAI_KEY`, `WORKSHOP_AZURE_OPENAI_CHAT`, `WORKSHOP_AZURE_OPENAI_EMBEDDING`, `WORKSHOP_AZURE_SUBSCRIPTION_ID`, `WORKSHOP_AZURE_LOCATION`, and optional local model values.
-
-## Writing style
-
-This is attendee-facing teaching material. Prefer plain, direct prose. Keep time estimates and pacing tables in sync with the root `README.md` schedule when you change the length of a part.
+- Read the nearest part README before changing a lab or snapshot.
+- Prefer plain, direct, attendee-facing prose. Keep time estimates and the root
+  schedule aligned when a part's length changes.
+- Follow the path-specific instructions in `.github/instructions/` for workshop
+  prose, snapshot code, and the shared GenAiLab progression.
+- Use the `workshop-testing` skill for attendee-style walkthroughs, snapshot
+  reconciliation, or workshop test reports.
+- Consult `docs/instructor/` for volatile template behavior and instructor-only
+  implementation context instead of duplicating those details here.

--- a/.github/instructions/genailab.instructions.md
+++ b/.github/instructions/genailab.instructions.md
@@ -1,0 +1,23 @@
+---
+description: "Use when changing GenAiLab, AI Web Chat template instructions, Azure AI Search migration guidance, or Parts 4, 10, and 11."
+applyTo: "Part 04 - AI Web Chat Template/**,Part 10 - Choosing Providers and Services/**,Part 11 - Deployment/**,docs/instructor/AICHATWEB_TEMPLATE_NOTES.md"
+---
+
+# GenAiLab progression
+
+- Treat Parts 4, 10, and 11 as one app progression. Part 4 scaffolds GenAiLab,
+  Part 10 changes its production service choices, and the Part 11 snapshot is the
+  deployment-ready result.
+- Preserve the exact Part 4 scaffold command unless intentionally updating the
+  entire progression. Its provider, vector-store, Aspire, name, and output options
+  determine what later instructions can assume.
+- The AppHost deliberately uses the existing Azure OpenAI connection instead of
+  provisioning a new account. Preserve that behavior and the corresponding
+  attendee step across Parts 4 and 11.
+- Keep Azure AI Search as the recommended Part 10/11 production path and Qdrant as
+  the documented fallback unless the workshop's provider strategy changes.
+- When template output, package requirements, or infrastructure behavior changes,
+  verify the current template and update the relevant READMEs, Part 11 snapshot,
+  and `docs/instructor/AICHATWEB_TEMPLATE_NOTES.md` together.
+- Do not commit `azure.yaml` or `.azure/`; deployment initialization generates
+  them at runtime.

--- a/.github/instructions/snapshot-code.instructions.md
+++ b/.github/instructions/snapshot-code.instructions.md
@@ -1,0 +1,23 @@
+---
+description: "Use when changing .NET workshop sample code, project files, packages, configuration, or README steps that produce a committed snapshot."
+applyTo: "Part 02 - Build Chat App/**,Part 03 - Add RAG/**,Part 05 - MCP Server Basics/**,Part 06 - Enhanced MCP Server/**,Part 08 - Agent Framework Basics/**,Part 09 - Adding AI to an Existing App/**,Part 11 - Deployment/**"
+---
+
+# Workshop code snapshots
+
+- Treat each snapshot as the result of following its lab README, not as an
+  independent sample. Keep commands, package references, configuration names,
+  source code, and observable behavior aligned in both directions.
+- Preserve the workshop's scaffold-first flow. Projects taught as generated must
+  begin with the documented `dotnet new` command; record required package updates
+  as explicit attendee steps.
+- Read the affected project files before changing package versions. Preserve
+  deliberate pins and cross-project consistency documented by the surrounding lab.
+- Store credentials in user secrets or the configuration mechanism taught by the
+  lab. Never add real endpoints, keys, generated `.azure/` state, or deployment
+  output to a snapshot.
+- Do not commit `bin/`, `obj/`, `.vs/`, or `TestResults/` directories.
+- Build every affected target in Release and treat warnings as regressions. Use
+  `.github/workflows/dotnet-build.yml` for the authoritative SDK and target list.
+- Use the `workshop-testing` skill when the task requires reproducing a snapshot
+  from the README or validating the lab as an attendee.

--- a/.github/instructions/workshop-content.instructions.md
+++ b/.github/instructions/workshop-content.instructions.md
@@ -1,0 +1,22 @@
+---
+description: "Use when authoring or reviewing attendee workshop READMEs, lab instructions, pacing, or contributor documentation."
+applyTo: "README.md,Part */README.md,docs/**/*.md"
+---
+
+# Workshop content
+
+- Write for an attendee following the lab in order. Use plain, direct prose and
+  make commands runnable as written.
+- Use zero-padded folder names in paths (`Part 02 - ...`) and unpadded part names
+  in prose and headings (`Part 2`).
+- Check the root `README.md` before changing part names, ordering, duration, or
+  prerequisites. Keep its schedule aligned with meaningful pacing changes.
+- When instructions create or modify a committed sample, update the corresponding
+  snapshot in the same change. When snapshot behavior changes, update the README
+  that teaches it.
+- Keep instructor-only rationale in `docs/instructor/`; attendee READMEs should
+  contain only what attendees need to complete and understand the lab.
+- Validate changed Markdown using the commands and configuration in
+  `.github/workflows/markdownlint.yml` and `.github/workflows/link-check.yml`.
+- Use the `workshop-testing` skill for a literal attendee walkthrough, snapshot
+  reconciliation, or a workshop test report.


### PR DESCRIPTION
## Summary

- reduce the always-loaded repository instructions from about 910 words to about 230 words
- move workshop-writing and snapshot conventions into path-scoped instruction files
- isolate the cross-part GenAiLab constraints for Parts 4, 10, and 11
- keep exact build commands, template details, and attendee walkthrough procedures with their existing authoritative workflows, docs, and skill

## Why

The previous global file mixed durable repository invariants with the part catalog, exact CI targets, package pins, credentials, and volatile template behavior. This keeps the global context focused while preserving targeted guidance through `applyTo` patterns and keyword-rich descriptions.

## Validation

- VS Code customization diagnostics: clean
- repository Markdown lint: passed
- instruction frontmatter and non-global `applyTo` checks: passed
- `git diff --check`: passed

No .NET build was run because this changes only Copilot customization Markdown.