### PR TITLE
Document dependency version constraints

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   # Dependabot configuration for workshop-wide NuGet package updates
+  # Review docs/instructor/DEPENDENCY_POLICY.md before accepting generated changes.
   - package-ecosystem: "nuget"
     directories:
       - "/Part 02 - Build Chat App/ChatApp/"

--- a/.github/instructions/genailab.instructions.md
+++ b/.github/instructions/genailab.instructions.md
@@ -8,6 +8,8 @@ applyTo: "Part 04 - AI Web Chat Template/**,Part 10 - Choosing Providers and Ser
 - Treat Parts 4, 10, and 11 as one app progression. Part 4 scaffolds GenAiLab,
   Part 10 changes its production service choices, and the Part 11 snapshot is the
   deployment-ready result.
+- Read `docs/instructor/DEPENDENCY_POLICY.md` before changing package versions in
+  this progression. Preserve its security overrides and coordinated Aspire set.
 - Preserve the exact Part 4 scaffold command unless intentionally updating the
   entire progression. Its provider, vector-store, Aspire, name, and output options
   determine what later instructions can assume.

--- a/.github/instructions/snapshot-code.instructions.md
+++ b/.github/instructions/snapshot-code.instructions.md
@@ -11,8 +11,10 @@ applyTo: "Part 02 - Build Chat App/**,Part 03 - Add RAG/**,Part 05 - MCP Server 
 - Preserve the workshop's scaffold-first flow. Projects taught as generated must
   begin with the documented `dotnet new` command; record required package updates
   as explicit attendee steps.
-- Read the affected project files before changing package versions. Preserve
-  deliberate pins and cross-project consistency documented by the surrounding lab.
+- Read the affected project files and
+  `docs/instructor/DEPENDENCY_POLICY.md` before changing package versions. Preserve
+  security overrides, compatibility boundaries, coordinated sets, and cross-project
+  consistency documented by the surrounding lab.
 - Store credentials in user secrets or the configuration mechanism taught by the
   lab. Never add real endpoints, keys, generated `.azure/` state, or deployment
   output to a snapshot.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ New test reports are written here using the template and skill at [`.github/skil
 
 - **[ATTENDEE_AI_ACCESS.md](instructor/ATTENDEE_AI_ACCESS.md)** - Instructor-only note on providing an AI access fallback (azure-ai-proxy-lite) for attendees who can't provision their own [Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) resource
 - **[AICHATWEB_TEMPLATE_NOTES.md](instructor/AICHATWEB_TEMPLATE_NOTES.md)** - Background for Parts 4 and 11: why the workshop replaces the template's Azure provisioning code, what the template switches do, and the failure modes that show up in the room
+- **[DEPENDENCY_POLICY.md](instructor/DEPENDENCY_POLICY.md)** - Maintainer inventory of protected dependency versions, why they are constrained, and when they can be changed or removed
 - **[MCP_INSTRUCTOR_GUIDE.md](instructor/MCP_INSTRUCTOR_GUIDE.md)** - Complete instructor guide for teaching Parts 5-7 (MCP components) of the workshop
 - **[END_OF_WORKSHOP_RESOURCES_SLIDE.md](instructor/END_OF_WORKSHOP_RESOURCES_SLIDE.md)** - Closing slide content for end-of-workshop resource handoff
 

--- a/docs/instructor/DEPENDENCY_POLICY.md
+++ b/docs/instructor/DEPENDENCY_POLICY.md
@@ -47,10 +47,11 @@ known advisories and preserves the lab behavior.
 
 ## Versions that are not protected pins
 
-Routine exact references such as `Microsoft.Extensions.*`, OpenTelemetry, and
-patch-level runtime packages generally record the last tested snapshot. They may
-be updated, but related packages should stay on compatible versions and every
-affected snapshot must continue to build without warnings.
+Routine exact references such as stable `Microsoft.Extensions.*` packages other
+than `Microsoft.Extensions.DataIngestion*`, OpenTelemetry, and patch-level runtime
+packages generally record the last tested snapshot. They may be updated, but
+related packages should stay on compatible versions and every affected snapshot
+must continue to build without warnings.
 
 Major updates are never routine in this repository. For example,
 `ModelContextProtocol` 1.x to 2.x, `Microsoft.OpenApi` 2.x to 3.x, or an Agent

--- a/docs/instructor/DEPENDENCY_POLICY.md
+++ b/docs/instructor/DEPENDENCY_POLICY.md
@@ -1,0 +1,76 @@
+# Dependency version policy
+
+This document is the source of truth for dependency versions that should not be
+updated independently. It exists for maintainers and reviewers; attendee READMEs
+should still explain any pin that attendees must preserve while completing a lab.
+
+The committed projects use exact package versions so workshop snapshots remain
+reproducible. An exact version is not automatically a protected pin. Most package
+updates are acceptable after the snapshot, its README, and the affected behavior
+have been validated together.
+
+## Constraint types
+
+- **Security override:** a direct reference promotes a safe transitive version.
+  Keep it until the parent dependency resolves a safe version without the override.
+- **Compatibility boundary:** another package or generated API limits the allowed
+  version range. Do not cross the boundary without updating the dependent package
+  and code together.
+- **Coordinated set:** several packages, projects, or workshop parts describe one
+  working state. Move the full set together.
+- **Template baseline:** the version records the output or APIs of a template used
+  by the lab. Re-scaffold and compare before changing it.
+
+## Active constraints
+
+### Security and compatibility overrides
+
+| Dependency | Scope | Why it is direct or constrained | Revisit when |
+| --- | --- | --- | --- |
+| `Microsoft.Bcl.Memory` 10.0.10 | Part 3 MEDI checkpoint; Part 11 GenAiLab web app | Promotes the transitive dependency brought in by tokenizer packages above a version with a high-severity advisory. | A restore without the direct reference resolves a non-vulnerable version. A newer safe patch may replace 10.0.10 after affected builds remain warning-free. |
+| `SQLitePCLRaw.bundle_e_sqlite3` 3.0.4 | Part 3 MEDI checkpoint; both Part 9 Products projects; Part 4 Docker-free instructions | Promotes the native SQLite bundle above the vulnerable transitive version used by SqliteVec or the local template path. | The parent packages resolve a non-vulnerable native bundle without the override. A newer safe patch is allowed after local SQLite and vector-search behavior is tested. |
+| `Microsoft.OpenApi` 2.7.5 | Both Part 9 Products projects | Originally added as a security override. It is also bounded by `Microsoft.AspNetCore.OpenApi` 10.0.x, which requires `Microsoft.OpenApi` below 3.0. Updating only this package to 3.x produces `NU1608` and source-generator compile errors. | The selected `Microsoft.AspNetCore.OpenApi` version supports 3.x, or its transitive dependency is safe enough to remove the direct reference. Update the start and completed snapshots together. |
+
+The versions above are the currently verified safe versions, not permanent maximums.
+For a security override, prefer the smallest update that keeps the graph free of
+known advisories and preserves the lab behavior.
+
+### Coordinated and template-bound versions
+
+| Dependency set | Scope | Constraint | Revisit procedure |
+| --- | --- | --- | --- |
+| Aspire 13.5.3 packages and AppHost SDK | Parts 4, 10, and 11 GenAiLab progression | Part 4 moves the template from Aspire 13.0.0 because that graph reports a high-severity MessagePack advisory. The SDK and Aspire packages form one tested set, and 13.5.3 requires `AspireUseCliBundle` to avoid `ASPIRE010`. | Update the Part 4 commands, Part 10 provider commands, Part 11 snapshot, and instructor template notes together. Test local orchestration and deployment configuration. |
+| Aspire AppHost SDK 13.4.6 | Part 9 `eShopLite-start` and `eShopLite` | This is the baseline inherited by the existing-app scenario. The start and answer projects must remain equivalent before AI changes are applied. It is not a permanent security pin. | Update both AppHost projects together, confirm the starting application still matches the lab, and run the completed AI flows. |
+| `Microsoft.Extensions.DataIngestion*` previews | Part 3 MEDI checkpoint and Part 11 GenAiLab | These packages are prerelease and their APIs follow the template's ingestion pipeline. Different parts may intentionally reflect different tested template states. | Re-run the relevant template or checkpoint flow, reconcile API changes, and update instructions and snapshots together. Do not normalize versions across parts solely for consistency. |
+| `Aspire.Azure.AI.OpenAI` preview | Part 11 GenAiLab | No stable package exists for the template integration used by this snapshot, and its compatibility is tied to the GenAiLab Aspire set. | Validate against the current AI Web Chat template and the complete GenAiLab dependency set before changing it. |
+| `Microsoft.SemanticKernel.Connectors.SqliteVec` preview | Parts 3 and 9 | The workshop relies on prerelease vector-store APIs and on its SQLite transitive graph. | Validate compilation, ingestion/search behavior, and the SQLite security override before changing it. |
+
+## Versions that are not protected pins
+
+Routine exact references such as `Microsoft.Extensions.*`, OpenTelemetry, and
+patch-level runtime packages generally record the last tested snapshot. They may
+be updated, but related packages should stay on compatible versions and every
+affected snapshot must continue to build without warnings.
+
+Major updates are never routine in this repository. For example,
+`ModelContextProtocol` 1.x to 2.x, `Microsoft.OpenApi` 2.x to 3.x, or an Agent
+Framework release with API changes must be isolated and checked against the lab's
+code and teaching flow. Do not group unrelated major updates into one pull request.
+
+## Reviewing a dependency change
+
+1. Classify each update as routine, security override, compatibility boundary,
+   coordinated set, or template baseline.
+1. Check the affected README for package commands and explanations. Update it when
+   the committed snapshot would no longer be produced by following those steps.
+1. Keep paired projects aligned, especially Part 9's start and completed snapshots
+   and the Parts 4, 10, and 11 GenAiLab progression.
+1. Inspect the resolved transitive graph and vulnerability report. Confirm that a
+   proposed removal of an override still resolves a safe version.
+1. Build every affected CI target in Release with zero warnings. For major,
+   prerelease, template, or provider changes, also run the relevant attendee flow.
+1. Record why a protected pin changed or was removed in the pull request and update
+   this inventory in the same change.
+
+Use the `workshop-testing` skill when an update requires re-scaffolding a project,
+reconciling a snapshot, or exercising the workshop as an attendee.


### PR DESCRIPTION
## Summary

- add a canonical maintainer inventory of protected dependency versions
- distinguish security overrides, compatibility boundaries, coordinated sets, template baselines, and ordinary exact snapshot versions
- document when each constraint can be updated or removed
- link the policy from contributor docs, snapshot instructions, and Dependabot configuration

## Context

Dependency rationale was previously spread across attendee READMEs, instructor template notes, and historical test reports. This gives Dependabot reviewers one current source of truth while preserving concise attendee-facing explanations where needed.

## Validation

- VS Code diagnostics: clean
- repository Markdown lint: passed
- documented project locations and versions: verified
- documentation targets: verified
- `git diff --check`: passed

No .NET build was run because this changes documentation and guidance only.