### PR TITLE
Isolate specialized Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,12 +24,22 @@ updates:
       major-updates:
         patterns:
           - "*"
+        exclude-patterns:
+          - "Microsoft.Bcl.Memory"
+          - "Microsoft.Extensions.DataIngestion*"
+          - "Microsoft.SemanticKernel.Connectors.SqliteVec"
+          - "SQLitePCLRaw.bundle_e_sqlite3"
         update-types:
           - "major"
         group-by: "dependency-name"
       routine-minor-patch:
         patterns:
           - "*"
+        exclude-patterns:
+          - "Microsoft.Bcl.Memory"
+          - "Microsoft.Extensions.DataIngestion*"
+          - "Microsoft.SemanticKernel.Connectors.SqliteVec"
+          - "SQLitePCLRaw.bundle_e_sqlite3"
         update-types:
           - "minor"
           - "patch"
@@ -47,12 +57,22 @@ updates:
       major-updates:
         patterns:
           - "*"
+        exclude-patterns:
+          - "Aspire.AppHost.Sdk"
+          - "Microsoft.OpenApi"
+          - "Microsoft.SemanticKernel.Connectors.SqliteVec"
+          - "SQLitePCLRaw.bundle_e_sqlite3"
         update-types:
           - "major"
         group-by: "dependency-name"
       routine-minor-patch:
         patterns:
           - "*"
+        exclude-patterns:
+          - "Aspire.AppHost.Sdk"
+          - "Microsoft.OpenApi"
+          - "Microsoft.SemanticKernel.Connectors.SqliteVec"
+          - "SQLitePCLRaw.bundle_e_sqlite3"
         update-types:
           - "minor"
           - "patch"
@@ -85,6 +105,10 @@ updates:
       routine-minor-patch:
         patterns:
           - "*"
+        exclude-patterns:
+          - "Aspire.*"
+          - "Microsoft.Bcl.Memory"
+          - "Microsoft.Extensions.DataIngestion*"
         update-types:
           - "minor"
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,22 +57,12 @@ updates:
       major-updates:
         patterns:
           - "*"
-        exclude-patterns:
-          - "Aspire.AppHost.Sdk"
-          - "Microsoft.OpenApi"
-          - "Microsoft.SemanticKernel.Connectors.SqliteVec"
-          - "SQLitePCLRaw.bundle_e_sqlite3"
         update-types:
           - "major"
         group-by: "dependency-name"
       routine-minor-patch:
         patterns:
           - "*"
-        exclude-patterns:
-          - "Aspire.AppHost.Sdk"
-          - "Microsoft.OpenApi"
-          - "Microsoft.SemanticKernel.Connectors.SqliteVec"
-          - "SQLitePCLRaw.bundle_e_sqlite3"
         update-types:
           - "minor"
           - "patch"
@@ -99,6 +89,11 @@ updates:
       major-updates:
         patterns:
           - "*"
+        exclude-patterns:
+          - "Aspire.AppHost.Sdk"
+          - "Microsoft.OpenApi"
+          - "Microsoft.SemanticKernel.Connectors.SqliteVec"
+          - "SQLitePCLRaw.bundle_e_sqlite3"
         update-types:
           - "major"
         group-by: "dependency-name"
@@ -106,9 +101,10 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "Aspire.*"
-          - "Microsoft.Bcl.Memory"
-          - "Microsoft.Extensions.DataIngestion*"
+          - "Aspire.AppHost.Sdk"
+          - "Microsoft.OpenApi"
+          - "Microsoft.SemanticKernel.Connectors.SqliteVec"
+          - "SQLitePCLRaw.bundle_e_sqlite3"
         update-types:
           - "minor"
           - "patch"
@@ -137,6 +133,10 @@ updates:
       routine-minor-patch:
         patterns:
           - "*"
+        exclude-patterns:
+          - "Aspire.*"
+          - "Microsoft.Bcl.Memory"
+          - "Microsoft.Extensions.DataIngestion*"
         update-types:
           - "minor"
           - "patch"

--- a/.github/skills/dependency-update-review/SKILL.md
+++ b/.github/skills/dependency-update-review/SKILL.md
@@ -88,6 +88,7 @@ Then scale validation to risk:
 | Compatibility boundary or major | Compile dependent/generated code and run the relevant lab flow |
 | Coordinated set | Build and exercise every member of the set together |
 | Template baseline or prerelease | Re-scaffold, compare, and run the affected attendee flow |
+| Fast-moving AI framework minor | Inspect release notes and run the affected lab flow when behavior or APIs changed |
 
 Do not substitute a repository-wide green build for a required template or runtime
 check.
@@ -103,6 +104,15 @@ Update the PR branch from its base only as part of an explicitly requested repai
 After repairs, rerun the failed focused check first, then all validation required
 by the classification. Run Markdown lint and link checks when documentation
 changes, and finish with `git diff --check`.
+
+Before marking a repaired PR ready to merge:
+
+- Compare the final diff with the PR title and description. Remove generated
+  package entries and release notes for updates that were reverted, and correct
+  package counts.
+- Record retained protected pins and their policy rationale in the PR description.
+- Reply to each addressed review comment with the repair and validation evidence,
+  then resolve the thread.
 
 ## Disposition rules
 
@@ -127,4 +137,5 @@ Return:
 3. **Classification:** one row per package or coordinated set.
 4. **Findings:** blockers and risks, highest severity first, with file references.
 5. **Validation:** commands run and their outcomes, including skipped checks.
-6. **Required action:** the smallest next step that makes the disposition actionable.
+6. **Required action:** the smallest next step that makes the disposition actionable
+  and reviewable.

--- a/docs/instructor/DEPENDENCY_POLICY.md
+++ b/docs/instructor/DEPENDENCY_POLICY.md
@@ -75,6 +75,9 @@ to apply this checklist consistently to Dependabot and manual package updates.
    prerelease, template, or provider changes, also run the relevant attendee flow.
 1. Record why a protected pin changed or was removed in the pull request and update
    this inventory in the same change.
+1. After repairing a generated dependency pull request, reconcile its title and
+  description with the final diff and resolve review threads only after recording
+  the validation evidence.
 
 Use the `workshop-testing` skill when an update requires re-scaffolding a project,
 reconciling a snapshot, or exercising the workshop as an attendee.


### PR DESCRIPTION
## Summary

- add explicit `exclude-patterns` so wildcard routine and major groups cannot absorb protected, template-bound, Aspire, or ingestion dependencies
- require repaired dependency PR titles and descriptions to match their final diffs
- require replies and resolution for addressed review threads
- add focused validation guidance for fast-moving AI framework minor updates

## Why

Dependabot opened protected-only PRs #605, #607, and #608, then superseded them with routine PRs #609, #610, and #611 because the wildcard fallback groups still matched the protected packages. Repairing those routine PRs also left their generated descriptions inconsistent with the final diffs until review caught the mismatch.

This change makes specialized groups mutually exclusive with their fallback groups and records metadata reconciliation as part of the repair workflow.

## Validation

- `npx --yes markdownlint-cli '.github/skills/dependency-update-review/SKILL.md' 'docs/instructor/DEPENDENCY_POLICY.md'`
- `npx --yes markdown-link-check@3 --config .markdown-link-check.json --quiet --retry '.github/skills/dependency-update-review/SKILL.md' 'docs/instructor/DEPENDENCY_POLICY.md'`
- YAML diagnostics: no errors
- `git diff --check`