### PR TITLE
Adopt typed structured output for MCP workshop tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,7 @@ updates:
     directories:
       - "/Part 05 - MCP Server Basics/MyMcpServer/"
       - "/Part 06 - Enhanced MCP Server/ContosoOrdersMcpServer/"
+      - "/tests/McpStructuredOutputTests/"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -14,6 +14,7 @@ on:
       - "Part 08 - Agent Framework Basics/**"
       - "Part 09 - Adding AI to an Existing App/**"
       - "Part 11 - Deployment/**"
+      - "tests/McpStructuredOutputTests/**"
   pull_request:
     branches:
       - main
@@ -53,6 +54,8 @@ on:
       - "Part 11 - Deployment/**/*.sln"
       - "Part 11 - Deployment/**/*.props"
       - "Part 11 - Deployment/**/*.targets"
+      - "tests/McpStructuredOutputTests/**/*.cs"
+      - "tests/McpStructuredOutputTests/**/*.csproj"
   workflow_dispatch:
 
 jobs:
@@ -100,3 +103,24 @@ jobs:
 
       - name: Build solution
         run: dotnet build "${{ matrix.solution }}" --no-restore --configuration Release
+
+  mcp-structured-output:
+    name: MCP structured output
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Build MCP servers
+        run: |
+          dotnet build "Part 05 - MCP Server Basics/MyMcpServer/MyMcpServer.csproj" --configuration Release
+          dotnet build "Part 06 - Enhanced MCP Server/ContosoOrdersMcpServer/ContosoOrdersMcpServer.csproj" --configuration Release
+
+      - name: Validate MCP structured output
+        run: dotnet run --project tests/McpStructuredOutputTests/McpStructuredOutputTests.csproj --configuration Release

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -58,6 +58,9 @@ on:
       - "tests/McpStructuredOutputTests/**/*.csproj"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -58,9 +58,6 @@ on:
       - "tests/McpStructuredOutputTests/**/*.csproj"
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/Part 05 - MCP Server Basics/MyMcpServer/Tools/RandomNumberTools.cs
+++ b/Part 05 - MCP Server Basics/MyMcpServer/Tools/RandomNumberTools.cs
@@ -9,7 +9,7 @@ namespace MyMcpServer.Tools;
 /// </summary>
 internal class RandomNumberTools
 {
-    [McpServerTool]
+    [McpServerTool(UseStructuredContent = true)]
     [Description("Generates a random number between the specified minimum and maximum values.")]
     public int GetRandomNumber(
         [Description("Minimum value (inclusive)")] int min = 0,

--- a/Part 05 - MCP Server Basics/MyMcpServer/Tools/WeatherTools.cs
+++ b/Part 05 - MCP Server Basics/MyMcpServer/Tools/WeatherTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Text.Json;
 using ModelContextProtocol.Server;
 
 namespace MyMcpServer.Tools;
@@ -14,52 +13,42 @@ internal class WeatherTools
         "Heavy Rain", "Snow", "Fog", "Windy", "Stormy"
     ];
 
-    [McpServerTool]
+    [McpServerTool(UseStructuredContent = true)]
     [Description("Gets current weather for a specified city.")]
-    public async Task<string> GetCurrentWeather(
+    public async Task<CurrentWeather> GetCurrentWeather(
         [Description("Name of the city to get weather for")] string city)
     {
         // Simulate API call delay
         await Task.Delay(500);
 
         // Simulate weather API call with realistic data
-        var weatherData = new
-        {
-            City = city,
-            Temperature = Random.Shared.Next(-10, 35) + "°C",
-            Condition = GetRandomWeatherCondition(),
-            Humidity = Random.Shared.Next(30, 90) + "%",
-            WindSpeed = Random.Shared.Next(5, 25) + " km/h",
-            Pressure = Random.Shared.Next(980, 1040) + " hPa",
-            LastUpdated = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss")
-        };
-
-        return JsonSerializer.Serialize(weatherData, new JsonSerializerOptions { WriteIndented = true });
+        return new CurrentWeather(
+            city,
+            Random.Shared.Next(-10, 35) + "°C",
+            GetRandomWeatherCondition(),
+            Random.Shared.Next(30, 90) + "%",
+            Random.Shared.Next(5, 25) + " km/h",
+            Random.Shared.Next(980, 1040) + " hPa",
+            DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
     }
 
-    [McpServerTool]
+    [McpServerTool(UseStructuredContent = true)]
     [Description("Gets a 5-day weather forecast for a specified city starting from tomorrow.")]
-    public async Task<string> GetWeatherForecast(
+    public async Task<WeatherForecast> GetWeatherForecast(
         [Description("Name of the city to get forecast for")] string city)
     {
         // Simulate API call delay
         await Task.Delay(800);
 
-        var forecast = new
-        {
-            City = city,
-            Forecast = Enumerable.Range(1, 5).Select(day => new
-            {
-                Date = DateTime.Now.AddDays(day).ToString("yyyy-MM-dd"),
-                DayName = DateTime.Now.AddDays(day).ToString("dddd"),
-                HighTemp = Random.Shared.Next(15, 35) + "°C",
-                LowTemp = Random.Shared.Next(-5, 20) + "°C",
-                Condition = GetRandomWeatherCondition(),
-                ChanceOfRain = Random.Shared.Next(0, 100) + "%"
-            }).ToArray()
-        };
+        var forecast = Enumerable.Range(1, 5).Select(day => new WeatherForecastDay(
+            DateTime.Now.AddDays(day).ToString("yyyy-MM-dd"),
+            DateTime.Now.AddDays(day).ToString("dddd"),
+            Random.Shared.Next(15, 35) + "°C",
+            Random.Shared.Next(-5, 20) + "°C",
+            GetRandomWeatherCondition(),
+            Random.Shared.Next(0, 100) + "%")).ToArray();
 
-        return JsonSerializer.Serialize(forecast, new JsonSerializerOptions { WriteIndented = true });
+        return new WeatherForecast(city, forecast);
     }
 
     private static string GetRandomWeatherCondition()
@@ -67,3 +56,22 @@ internal class WeatherTools
         return WeatherConditions[Random.Shared.Next(WeatherConditions.Length)];
     }
 }
+
+internal sealed record CurrentWeather(
+    string City,
+    string Temperature,
+    string Condition,
+    string Humidity,
+    string WindSpeed,
+    string Pressure,
+    string LastUpdated);
+
+internal sealed record WeatherForecast(string City, WeatherForecastDay[] Forecast);
+
+internal sealed record WeatherForecastDay(
+    string Date,
+    string DayName,
+    string HighTemp,
+    string LowTemp,
+    string Condition,
+    string ChanceOfRain);

--- a/Part 05 - MCP Server Basics/README.md
+++ b/Part 05 - MCP Server Basics/README.md
@@ -197,7 +197,8 @@ builder.Services
 
 **`Tools/RandomNumberTools.cs`** - Contains example tools that AI agents can use. We'll customize this for weather functionality.
 
-The template generates a simple `RandomNumberTools` class with a `GetRandomNumber` method:
+Update the template-generated `RandomNumberTools` class to enable structured
+output for its scalar result:
 
 ```csharp
 using System.ComponentModel;
@@ -209,7 +210,7 @@ using ModelContextProtocol.Server;
 /// </summary>
 internal class RandomNumberTools
 {
-    [McpServerTool]
+   [McpServerTool(UseStructuredContent = true)]
     [Description("Generates a random number between the specified minimum and maximum values.")]
     public int GetRandomNumber(
         [Description("Minimum value (inclusive)")] int min = 0,
@@ -245,7 +246,6 @@ Instead of replacing the existing tools, let's add new weather tools alongside t
 
 ```csharp
 using System.ComponentModel;
-using System.Text.Json;
 using ModelContextProtocol.Server;
 
 namespace MyMcpServer.Tools;
@@ -256,56 +256,46 @@ namespace MyMcpServer.Tools;
 internal class WeatherTools
 {
     private static readonly string[] WeatherConditions = [
-        "Sunny", "Partly Cloudy", "Cloudy", "Overcast", "Light Rain", 
+      "Sunny", "Partly Cloudy", "Cloudy", "Overcast", "Light Rain",
         "Heavy Rain", "Snow", "Fog", "Windy", "Stormy"
     ];
 
-    [McpServerTool]
+      [McpServerTool(UseStructuredContent = true)]
     [Description("Gets current weather for a specified city.")]
-    public async Task<string> GetCurrentWeather(
+      public async Task<CurrentWeather> GetCurrentWeather(
         [Description("Name of the city to get weather for")] string city)
     {
         // Simulate API call delay
         await Task.Delay(500);
         
         // Simulate weather API call with realistic data
-        var weatherData = new
-        {
-            City = city,
-            Temperature = Random.Shared.Next(-10, 35) + "°C",
-            Condition = GetRandomWeatherCondition(),
-            Humidity = Random.Shared.Next(30, 90) + "%",
-            WindSpeed = Random.Shared.Next(5, 25) + " km/h",
-            Pressure = Random.Shared.Next(980, 1040) + " hPa",
-            LastUpdated = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss")
-        };
-
-        return JsonSerializer.Serialize(weatherData, new JsonSerializerOptions { WriteIndented = true });
+         return new CurrentWeather(
+             city,
+             Random.Shared.Next(-10, 35) + "°C",
+             GetRandomWeatherCondition(),
+             Random.Shared.Next(30, 90) + "%",
+             Random.Shared.Next(5, 25) + " km/h",
+             Random.Shared.Next(980, 1040) + " hPa",
+             DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
     }
 
-    [McpServerTool]
+          [McpServerTool(UseStructuredContent = true)]
     [Description("Gets a 5-day weather forecast for a specified city starting from tomorrow.")]
-    public async Task<string> GetWeatherForecast(
+          public async Task<WeatherForecast> GetWeatherForecast(
         [Description("Name of the city to get forecast for")] string city)
     {
         // Simulate API call delay
         await Task.Delay(800);
         
-        var forecast = new
-        {
-            City = city,
-            Forecast = Enumerable.Range(1, 5).Select(day => new
-            {
-                Date = DateTime.Now.AddDays(day).ToString("yyyy-MM-dd"),
-                DayName = DateTime.Now.AddDays(day).ToString("dddd"),
-                HighTemp = Random.Shared.Next(15, 35) + "°C",
-                LowTemp = Random.Shared.Next(-5, 20) + "°C",
-                Condition = GetRandomWeatherCondition(),
-                ChanceOfRain = Random.Shared.Next(0, 100) + "%"
-            }).ToArray()
-        };
+            var forecast = Enumerable.Range(1, 5).Select(day => new WeatherForecastDay(
+                  DateTime.Now.AddDays(day).ToString("yyyy-MM-dd"),
+                  DateTime.Now.AddDays(day).ToString("dddd"),
+                  Random.Shared.Next(15, 35) + "°C",
+                  Random.Shared.Next(-5, 20) + "°C",
+                  GetRandomWeatherCondition(),
+                  Random.Shared.Next(0, 100) + "%")).ToArray();
 
-        return JsonSerializer.Serialize(forecast, new JsonSerializerOptions { WriteIndented = true });
+            return new WeatherForecast(city, forecast);
     }
 
     private static string GetRandomWeatherCondition()
@@ -313,6 +303,25 @@ internal class WeatherTools
         return WeatherConditions[Random.Shared.Next(WeatherConditions.Length)];
     }
 }
+
+internal sealed record CurrentWeather(
+   string City,
+   string Temperature,
+   string Condition,
+   string Humidity,
+   string WindSpeed,
+   string Pressure,
+   string LastUpdated);
+
+internal sealed record WeatherForecast(string City, WeatherForecastDay[] Forecast);
+
+internal sealed record WeatherForecastDay(
+   string Date,
+   string DayName,
+   string HighTemp,
+   string LowTemp,
+   string Condition,
+   string ChanceOfRain);
 ```
 
 1. **Register the new weather tools** in `Program.cs`. Update the file to register both tool classes:
@@ -371,10 +380,10 @@ Now that we've added our weather tools alongside the original random number tool
 
 Now that you've built your own MCP server, let's review the key concepts:
 
-1. **`[McpServerTool]` Attributes**: Mark methods as tools available to AI agents
+1. **`[McpServerTool]` Attributes**: Mark methods as tools available to AI agents; `UseStructuredContent = true` publishes the return type as an output schema
 2. **`[Description]` Attributes**: Provide context to AI agents about what tools do and what parameters mean
 3. **Async Methods**: Tools can perform async operations (database calls, API requests, etc.)
-4. **JSON Serialization**: MCP tools return structured data as JSON strings
+4. **Typed Structured Output**: The SDK serializes typed return values into MCP structured content, so clients can validate and consume the result directly
 5. **Realistic Data Simulation**: The tools simulate real API calls with delays and varied data
 
 ## Step 6: Configure VS Code to Use Your MCP Server
@@ -659,7 +668,7 @@ When your MCP server runs, you might see log output in VS Code's Output panel:
 - **MCP servers** extend AI agents with custom capabilities
 - **Tools** are methods marked with `[McpServerTool]` attribute
 - **Descriptions** help AI understand when and how to use tools
-- **JSON serialization** provides structured data to AI agents
+- **Typed structured output** gives AI agents a declared output schema and a directly consumable result
 
 ### Integration Points
 

--- a/Part 06 - Enhanced MCP Server/ContosoOrdersMcpServer/Tools/ContosoOrdersTools.cs
+++ b/Part 06 - Enhanced MCP Server/ContosoOrdersMcpServer/Tools/ContosoOrdersTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Text.Json;
 using ModelContextProtocol.Server;
 
 namespace ContosoOrdersMcpServer.Tools;
@@ -10,72 +9,47 @@ namespace ContosoOrdersMcpServer.Tools;
 /// </summary>
 internal class ContosoOrdersTools
 {
-    [McpServerTool]
+    [McpServerTool(UseStructuredContent = true)]
     [Description("Retrieves order information from the Contoso business system.")]
-    public string GetOrderDetails(
+    public OrderLookupResult GetOrderDetails(
         [Description("The order ID to look up")] string orderId)
     {
         // Simulate business data lookup
-        var orders = new Dictionary<string, object>
+        var orders = new Dictionary<string, OrderDetails>
         {
-            ["12345"] = new
-            {
-                Customer = "John Doe",
-                Total = "$150.00",
-                Status = "Shipped",
-                Items = new[] { "Camping Tent", "Sleeping Bag" },
-                ShippingAddress = "123 Adventure Lane, Outdoor City, OC 12345",
-                OrderDate = "2025-07-25",
-                TrackingNumber = "1Z999AA1012345675"
-            },
-            ["12346"] = new
-            {
-                Customer = "Jane Smith",
-                Total = "$89.99",
-                Status = "Processing",
-                Items = new[] { "Hiking Boots" },
-                ShippingAddress = "456 Trail Rd, Mountain View, MV 67890",
-                OrderDate = "2025-07-30",
-                TrackingNumber = (string?)null
-            },
-            ["12347"] = new
-            {
-                Customer = "Bob Johnson",
-                Total = "$245.50",
-                Status = "Delivered",
-                Items = new[] { "Backpack", "Water Bottle", "Trail Mix" },
-                ShippingAddress = "789 Summit St, Peak Town, PT 11111",
-                OrderDate = "2025-07-20",
-                TrackingNumber = "1Z999AA1012345676"
-            }
+            ["12345"] = new("John Doe", "$150.00", "Shipped",
+                ["Camping Tent", "Sleeping Bag"],
+                "123 Adventure Lane, Outdoor City, OC 12345", "2025-07-25", "1Z999AA1012345675"),
+            ["12346"] = new("Jane Smith", "$89.99", "Processing",
+                ["Hiking Boots"],
+                "456 Trail Rd, Mountain View, MV 67890", "2025-07-30", null),
+            ["12347"] = new("Bob Johnson", "$245.50", "Delivered",
+                ["Backpack", "Water Bottle", "Trail Mix"],
+                "789 Summit St, Peak Town, PT 11111", "2025-07-20", "1Z999AA1012345676")
         };
 
         if (orders.TryGetValue(orderId, out var order))
         {
-            return JsonSerializer.Serialize(order, new JsonSerializerOptions { WriteIndented = true });
+            return new OrderLookupResult(true, orderId, order, null);
         }
 
-        return $"Order {orderId} not found in the system.";
+        return new OrderLookupResult(false, orderId, null, $"Order {orderId} not found in the system.");
     }
 
-    [McpServerTool]
+    [McpServerTool(UseStructuredContent = true)]
     [Description("Searches for orders by customer name.")]
-    public string SearchOrdersByCustomer(
+    public CustomerOrderSearchResult SearchOrdersByCustomer(
         [Description("Customer name to search for")] string customerName)
     {
         // Simulate customer search
-        var customerOrders = new Dictionary<string, object[]>
+        var customerOrders = new Dictionary<string, CustomerOrder[]>
         {
-            ["John Doe"] = new object[] {
-                new { OrderId = "12345", Total = "$150.00", Status = "Shipped", Date = "2025-07-25" },
-                new { OrderId = "12350", Total = "$75.99", Status = "Delivered", Date = "2025-07-15" }
-            },
-            ["Jane Smith"] = new object[] {
-                new { OrderId = "12346", Total = "$89.99", Status = "Processing", Date = "2025-07-30" }
-            },
-            ["Bob Johnson"] = new object[] {
-                new { OrderId = "12347", Total = "$245.50", Status = "Delivered", Date = "2025-07-20" }
-            }
+            ["John Doe"] = [
+                new("12345", "$150.00", "Shipped", "2025-07-25"),
+                new("12350", "$75.99", "Delivered", "2025-07-15")
+            ],
+            ["Jane Smith"] = [new("12346", "$89.99", "Processing", "2025-07-30")],
+            ["Bob Johnson"] = [new("12347", "$245.50", "Delivered", "2025-07-20")]
         };
 
         var searchKey = customerOrders.Keys.FirstOrDefault(name =>
@@ -83,27 +57,27 @@ internal class ContosoOrdersTools
 
         if (searchKey != null)
         {
-            var result = new { Customer = searchKey, Orders = customerOrders[searchKey] };
-            return JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+            return new CustomerOrderSearchResult(true, searchKey, customerOrders[searchKey], null);
         }
 
-        return $"No orders found for customer '{customerName}'.";
+        return new CustomerOrderSearchResult(
+            false, customerName, [], $"No orders found for customer '{customerName}'.");
     }
 
-    [McpServerTool]
+    [McpServerTool(UseStructuredContent = true)]
     [Description("Gets inventory status for a specific product.")]
-    public string GetProductInventory(
+    public ProductInventoryResult GetProductInventory(
         [Description("Product name or SKU to check inventory for")] string productName)
     {
         // Simulate inventory lookup
-        var inventory = new Dictionary<string, object>
+        var inventory = new Dictionary<string, InventoryDetails>
         {
-            ["Camping Tent"] = new { SKU = "CT-001", InStock = 15, Price = "$89.99", Category = "Shelter" },
-            ["Sleeping Bag"] = new { SKU = "SB-002", InStock = 23, Price = "$59.99", Category = "Sleep" },
-            ["Hiking Boots"] = new { SKU = "HB-003", InStock = 8, Price = "$89.99", Category = "Footwear" },
-            ["Backpack"] = new { SKU = "BP-004", InStock = 12, Price = "$129.99", Category = "Gear" },
-            ["Water Bottle"] = new { SKU = "WB-005", InStock = 45, Price = "$19.99", Category = "Hydration" },
-            ["Trail Mix"] = new { SKU = "TM-006", InStock = 67, Price = "$8.99", Category = "Food" }
+            ["Camping Tent"] = new("CT-001", 15, "$89.99", "Shelter"),
+            ["Sleeping Bag"] = new("SB-002", 23, "$59.99", "Sleep"),
+            ["Hiking Boots"] = new("HB-003", 8, "$89.99", "Footwear"),
+            ["Backpack"] = new("BP-004", 12, "$129.99", "Gear"),
+            ["Water Bottle"] = new("WB-005", 45, "$19.99", "Hydration"),
+            ["Trail Mix"] = new("TM-006", 67, "$8.99", "Food")
         };
 
         var searchKey = inventory.Keys.FirstOrDefault(name =>
@@ -111,10 +85,37 @@ internal class ContosoOrdersTools
 
         if (searchKey != null)
         {
-            var result = new { Product = searchKey, Details = inventory[searchKey] };
-            return JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+            return new ProductInventoryResult(true, searchKey, inventory[searchKey], null);
         }
 
-        return $"Product '{productName}' not found in inventory.";
+        return new ProductInventoryResult(
+            false, productName, null, $"Product '{productName}' not found in inventory.");
     }
 }
+
+internal sealed record OrderLookupResult(bool Found, string OrderId, OrderDetails? Order, string? Message);
+
+internal sealed record OrderDetails(
+    string Customer,
+    string Total,
+    string Status,
+    string[] Items,
+    string ShippingAddress,
+    string OrderDate,
+    string? TrackingNumber);
+
+internal sealed record CustomerOrderSearchResult(
+    bool Found,
+    string Customer,
+    CustomerOrder[] Orders,
+    string? Message);
+
+internal sealed record CustomerOrder(string OrderId, string Total, string Status, string Date);
+
+internal sealed record ProductInventoryResult(
+    bool Found,
+    string Product,
+    InventoryDetails? Details,
+    string? Message);
+
+internal sealed record InventoryDetails(string Sku, int InStock, string Price, string Category);

--- a/Part 06 - Enhanced MCP Server/README.md
+++ b/Part 06 - Enhanced MCP Server/README.md
@@ -57,9 +57,9 @@ Open `ContosoOrdersMcpServer/Tools/ContosoOrdersTools.cs` and examine the three 
 ### Tool 1: Order Details Lookup
 
 ```csharp
-[McpServerTool]
+[McpServerTool(UseStructuredContent = true)]
 [Description("Retrieves order information from the Contoso business system.")]
-public string GetOrderDetails(
+public OrderLookupResult GetOrderDetails(
     [Description("The order ID to look up")] string orderId)
 ```
 
@@ -68,9 +68,9 @@ public string GetOrderDetails(
 ### Tool 2: Customer Order Search  
 
 ```csharp
-[McpServerTool]
+[McpServerTool(UseStructuredContent = true)]
 [Description("Searches for orders by customer name.")]
-public string SearchOrdersByCustomer(
+public CustomerOrderSearchResult SearchOrdersByCustomer(
     [Description("Customer name to search for")] string customerName)
 ```
 
@@ -79,9 +79,9 @@ public string SearchOrdersByCustomer(
 ### Tool 3: Product Inventory Status
 
 ```csharp
-[McpServerTool]
+[McpServerTool(UseStructuredContent = true)]
 [Description("Gets inventory status for a specific product.")]
-public string GetProductInventory(
+public ProductInventoryResult GetProductInventory(
     [Description("Product name or SKU to check inventory for")] string productName)
 ```
 
@@ -89,19 +89,25 @@ public string GetProductInventory(
 
 ## Step 3: Examine Business Data Structures
 
-The ContosoOrders tools return rich, structured business data:
+The ContosoOrders tools return typed business records. Setting
+`UseStructuredContent = true` makes the SDK publish an output schema for each
+tool and return its result as MCP structured content.
 
 ### Order Data Example
 
 ```json
 {
-  "Customer": "John Doe",
-  "Total": "$150.00",
-  "Status": "Shipped",
-  "Items": ["Camping Tent", "Sleeping Bag"],
-  "ShippingAddress": "123 Adventure Lane, Outdoor City, OC 12345",
-  "OrderDate": "2025-07-25",
-  "TrackingNumber": "1Z999AA1012345675"
+  "found": true,
+  "orderId": "12345",
+  "order": {
+    "customer": "John Doe",
+    "total": "$150.00",
+    "status": "Shipped",
+    "items": ["Camping Tent", "Sleeping Bag"],
+    "shippingAddress": "123 Adventure Lane, Outdoor City, OC 12345",
+    "orderDate": "2025-07-25",
+    "trackingNumber": "1Z999AA1012345675"
+  }
 }
 ```
 
@@ -109,13 +115,14 @@ The ContosoOrders tools return rich, structured business data:
 
 ```json
 {
-  "Customer": "John Doe",
-  "Orders": [
+  "found": true,
+  "customer": "John Doe",
+  "orders": [
     {
-      "OrderId": "12345",
-      "Total": "$150.00", 
-      "Status": "Shipped",
-      "Date": "2025-07-25"
+      "orderId": "12345",
+      "total": "$150.00",
+      "status": "Shipped",
+      "date": "2025-07-25"
     }
   ]
 }
@@ -125,12 +132,13 @@ The ContosoOrders tools return rich, structured business data:
 
 ```json
 {
-  "Product": "Camping Tent",
-  "Details": {
-    "SKU": "CT-001",
-    "InStock": 15,
-    "Price": "$89.99",
-    "Category": "Shelter"
+  "found": true,
+  "product": "Camping Tent",
+  "details": {
+    "sku": "CT-001",
+    "inStock": 15,
+    "price": "$89.99",
+    "category": "Shelter"
   }
 }
 ```
@@ -286,11 +294,11 @@ When building business MCP tools, consider these important aspects:
 ### Data Validation
 
 ```csharp
-public async Task<string> GetOrderDetails(string orderId)
+public OrderLookupResult GetOrderDetails(string orderId)
 {
     // Validate input parameters
     if (string.IsNullOrWhiteSpace(orderId))
-        return "Error: Order ID is required";
+    throw new ArgumentException("Order ID is required", nameof(orderId));
     
     // Sanitize inputs to prevent injection attacks
     orderId = orderId.Trim();
@@ -307,12 +315,14 @@ public async Task<string> GetOrderDetails(string orderId)
 try 
 {
     // Business logic here
-    return JsonSerializer.Serialize(result);
+  return result;
 }
 catch (Exception ex)
 {
     // Log errors securely (don't expose sensitive data)
-    return $"Error: Unable to process request. Reference ID: {Guid.NewGuid()}";
+  var referenceId = Guid.NewGuid();
+  _logger.LogError(ex, "Request failed. Reference ID: {ReferenceId}", referenceId);
+  throw new InvalidOperationException($"Unable to process request. Reference ID: {referenceId}");
 }
 ```
 
@@ -334,9 +344,9 @@ catch (Exception ex)
 Real business MCP servers often integrate with multiple systems:
 
 ```csharp
-[McpServerTool]
+[McpServerTool(UseStructuredContent = true)]
 [Description("Process a return request with inventory and accounting updates.")]
-public async Task<string> ProcessReturn(string orderId, string reason)
+public async Task<ReturnResult> ProcessReturn(string orderId, string reason)
 {
     // 1. Look up order details
     var order = await GetOrderFromDatabase(orderId);
@@ -350,11 +360,7 @@ public async Task<string> ProcessReturn(string orderId, string reason)
     // 4. Generate return label
     var label = await GenerateReturnLabel(order.ShippingAddress);
     
-    return JsonSerializer.Serialize(new { 
-        ReturnId = Guid.NewGuid(),
-        RefundAmount = order.Total,
-        ReturnLabel = label.TrackingNumber 
-    });
+    return new ReturnResult(Guid.NewGuid(), order.Total, label.TrackingNumber);
 }
 ```
 
@@ -372,8 +378,8 @@ public class ContosoOrdersTools
         _config = config;
     }
     
-    [McpServerTool]
-    public async Task<string> GetOrderDetails(string orderId)
+    [McpServerTool(UseStructuredContent = true)]
+    public async Task<OrderLookupResult> GetOrderDetails(string orderId)
     {
         var connectionString = _config["ContosoDb:ConnectionString"];
         var maxResults = _config.GetValue<int>("Orders:MaxResults", 100);
@@ -392,12 +398,12 @@ public class ContosoOrdersTools
 ```csharp
 private static readonly MemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
 
-[McpServerTool]
-public async Task<string> GetProductInventory(string productName)
+[McpServerTool(UseStructuredContent = true)]
+public async Task<ProductInventoryResult> GetProductInventory(string productName)
 {
     var cacheKey = $"inventory_{productName}";
     
-    if (_cache.TryGetValue(cacheKey, out string cachedResult))
+    if (_cache.TryGetValue(cacheKey, out ProductInventoryResult? cachedResult))
         return cachedResult;
     
     // Fetch fresh data
@@ -413,8 +419,8 @@ public async Task<string> GetProductInventory(string productName)
 ### Async Operations
 
 ```csharp
-[McpServerTool]
-public async Task<string> GetCustomerOrderSummary(string customerId)
+[McpServerTool(UseStructuredContent = true)]
+public async Task<CustomerOrderSummary> GetCustomerOrderSummary(string customerId)
 {
     // Run multiple operations in parallel
     var orderTask = GetCustomerOrders(customerId);
@@ -423,11 +429,10 @@ public async Task<string> GetCustomerOrderSummary(string customerId)
     
     await Task.WhenAll(orderTask, profileTask, preferencesTask);
     
-    return JsonSerializer.Serialize(new {
-        Orders = orderTask.Result,
-        Profile = profileTask.Result,
-        Preferences = preferencesTask.Result
-    });
+    return new CustomerOrderSummary(
+      orderTask.Result,
+      profileTask.Result,
+      preferencesTask.Result);
 }
 ```
 
@@ -438,8 +443,8 @@ public async Task<string> GetCustomerOrderSummary(string customerId)
 ### Tool Usage Logging
 
 ```csharp
-[McpServerTool]
-public async Task<string> GetOrderDetails(string orderId)
+[McpServerTool(UseStructuredContent = true)]
+public async Task<OrderLookupResult> GetOrderDetails(string orderId)
 {
     var stopwatch = Stopwatch.StartNew();
     
@@ -469,33 +474,35 @@ public async Task<string> GetOrderDetails(string orderId)
 
 ```csharp
 [Test]
-public async Task GetOrderDetails_ValidOrder_ReturnsOrderData()
+public void GetOrderDetails_ValidOrder_ReturnsOrderData()
 {
     // Arrange
     var tools = new ContosoOrdersTools();
     var orderId = "12345";
     
     // Act
-    var result = await tools.GetOrderDetails(orderId);
+    var result = tools.GetOrderDetails(orderId);
     
     // Assert
     Assert.That(result, Is.Not.Null);
-    var orderData = JsonSerializer.Deserialize<dynamic>(result);
-    Assert.That(orderData.Customer, Is.EqualTo("John Doe"));
+    Assert.That(result.Found, Is.True);
+    Assert.That(result.Order?.Customer, Is.EqualTo("John Doe"));
 }
 
 [Test] 
-public async Task GetOrderDetails_InvalidOrder_ReturnsNotFound()
+public void GetOrderDetails_InvalidOrder_ReturnsNotFound()
 {
     // Arrange
     var tools = new ContosoOrdersTools();
     var orderId = "99999";
     
     // Act
-    var result = await tools.GetOrderDetails(orderId);
+    var result = tools.GetOrderDetails(orderId);
     
     // Assert
-    Assert.That(result, Does.Contain("not found"));
+    Assert.That(result.Found, Is.False);
+    Assert.That(result.Order, Is.Null);
+    Assert.That(result.Message, Does.Contain("not found"));
 }
 ```
 

--- a/Part 06 - Enhanced MCP Server/README.md
+++ b/Part 06 - Enhanced MCP Server/README.md
@@ -403,7 +403,7 @@ public async Task<ProductInventoryResult> GetProductInventory(string productName
 {
     var cacheKey = $"inventory_{productName}";
     
-    if (_cache.TryGetValue(cacheKey, out ProductInventoryResult? cachedResult))
+    if (_cache.TryGetValue(cacheKey, out ProductInventoryResult? cachedResult) && cachedResult is not null)
         return cachedResult;
     
     // Fetch fresh data

--- a/docs/instructor/MCP_INSTRUCTOR_GUIDE.md
+++ b/docs/instructor/MCP_INSTRUCTOR_GUIDE.md
@@ -112,7 +112,7 @@ flowchart TD
 - Clear, descriptive tool names and descriptions
 - Proper parameter documentation with `[Description]` attributes
 - Error handling for invalid inputs
-- JSON serialization for structured responses
+- Typed return records with `UseStructuredContent = true` for declared output schemas
 
 ### Teaching Flow - Part 5 (45-60 minutes)
 
@@ -133,7 +133,7 @@ flowchart TD
    - Open `Tools/WeatherTools.cs`
    - Explain `[McpServerTool]` and `[Description]` attributes
    - Walk through `GetCurrentWeather` implementation
-   - Discuss JSON serialization patterns
+   - Show how typed records become output schemas and structured content
 
 3. **Build and Validate** (5 minutes)
    - Run `dotnet build` to verify compilation
@@ -150,6 +150,27 @@ flowchart TD
 1. **GitHub Copilot Testing** - Test weather queries
 2. **Error Handling** - Try invalid locations
 3. **Tool Discovery** - Verify Copilot can find and use tools
+
+### MCP SDK 2.x Scope Decision
+
+Keep the required lesson focused on typed structured output over stdio. This is
+the smallest SDK 2.x feature that improves the existing tools without adding a
+new hosting model or client dependency.
+
+| Capability | Decision | Instructor rationale |
+| --- | --- | --- |
+| Typed structured output | Adopt | Typed records publish output schemas and let clients consume results without parsing JSON strings. |
+| Stateless Streamable HTTP | Defer | Requires ASP.NET Core hosting and HTTP client configuration beyond the Part 5 transport lesson. |
+| Multi-round-trip elicitation | Defer | Needs a consequential write workflow plus accepted, declined, cancelled, and fallback paths. |
+| Standard headers and `[McpHeader]` | Defer | Useful with HTTP intermediaries, which these stdio samples do not use. |
+| Caching hints | Defer | Simulated in-memory lookups do not provide meaningful observable cache behavior. |
+| MCP Apps | Defer | Experimental APIs require host support and warning suppression. |
+| Tasks | Defer | Neither sample has a durable, long-running operation. |
+| Roots, sampling, and protocol logging | Do not teach | These SDK APIs are deprecated; use current tool and host patterns instead. |
+| Legacy SSE transport | Do not teach | Streamable HTTP supersedes the deprecated SSE transport. |
+
+Point out that a scalar result, such as `GetRandomNumber`, appears directly in
+structured content. SDK 2.x does not wrap it in a `{ "result": ... }` object.
 
 ### Common Student Questions
 

--- a/tests/McpStructuredOutputTests/McpStructuredOutputTests.csproj
+++ b/tests/McpStructuredOutputTests/McpStructuredOutputTests.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol.Core" Version="2.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/McpStructuredOutputTests/Program.cs
+++ b/tests/McpStructuredOutputTests/Program.cs
@@ -1,0 +1,194 @@
+﻿using System.Text.Json;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+
+var repositoryRoot = FindRepositoryRoot();
+
+await ValidatePart5Async(repositoryRoot);
+await ValidatePart6Async(repositoryRoot);
+
+Console.WriteLine("MCP structured output validation passed.");
+
+static async Task ValidatePart5Async(string repositoryRoot)
+{
+	await using var client = await CreateClientAsync(
+		repositoryRoot,
+		"Part 05 - MCP Server Basics/MyMcpServer/MyMcpServer.csproj");
+
+	var tools = await client.ListToolsAsync();
+	AssertToolSchema(tools, "get_current_weather", "city", "object", "city", "temperature", "condition");
+	AssertToolSchema(tools, "get_weather_forecast", "city", "object", "city", "forecast");
+	AssertToolSchema(tools, "get_random_number", null, "integer");
+
+	var weather = await client.CallToolAsync(
+		"get_current_weather",
+		new Dictionary<string, object?> { ["city"] = "Seattle" });
+	var weatherContent = GetStructuredContent(weather, "get_current_weather");
+	Assert(weatherContent.ValueKind == JsonValueKind.Object, "Weather result must be an object.");
+	Assert(weatherContent.GetProperty("city").GetString() == "Seattle", "Weather city was not preserved.");
+
+	var forecast = await client.CallToolAsync(
+		"get_weather_forecast",
+		new Dictionary<string, object?> { ["city"] = "Seattle" });
+	var forecastContent = GetStructuredContent(forecast, "get_weather_forecast");
+	Assert(forecastContent.GetProperty("forecast").GetArrayLength() == 5, "Forecast did not return five days.");
+
+	var random = await client.CallToolAsync(
+		"get_random_number",
+		new Dictionary<string, object?> { ["min"] = 1, ["max"] = 2 });
+	var randomContent = GetStructuredContent(random, "get_random_number");
+	Assert(randomContent.ValueKind == JsonValueKind.Number, "Scalar structured content must not use a result wrapper.");
+	Assert(randomContent.GetInt32() == 1, "Random number did not respect the requested range.");
+}
+
+static async Task ValidatePart6Async(string repositoryRoot)
+{
+	await using var client = await CreateClientAsync(
+		repositoryRoot,
+		"Part 06 - Enhanced MCP Server/ContosoOrdersMcpServer/ContosoOrdersMcpServer.csproj");
+
+	var tools = await client.ListToolsAsync();
+	AssertToolSchema(tools, "get_order_details", "orderId", "object", "found", "orderId");
+	AssertToolSchema(tools, "search_orders_by_customer", "customerName", "object", "found", "customer", "orders");
+	AssertToolSchema(tools, "get_product_inventory", "productName", "object", "found", "product");
+
+	var order = await client.CallToolAsync(
+		"get_order_details",
+		new Dictionary<string, object?> { ["orderId"] = "12345" });
+	var orderContent = GetStructuredContent(order, "get_order_details");
+	Assert(orderContent.GetProperty("found").GetBoolean(), "Known order was not found.");
+	Assert(
+		orderContent.GetProperty("order").GetProperty("customer").GetString() == "John Doe",
+		"Known order returned the wrong customer.");
+
+	var customerOrders = await client.CallToolAsync(
+		"search_orders_by_customer",
+		new Dictionary<string, object?> { ["customerName"] = "John Doe" });
+	var customerOrdersContent = GetStructuredContent(customerOrders, "search_orders_by_customer");
+	Assert(customerOrdersContent.GetProperty("found").GetBoolean(), "Known customer was not found.");
+	Assert(customerOrdersContent.GetProperty("orders").GetArrayLength() == 2, "Known customer returned the wrong orders.");
+
+	var inventory = await client.CallToolAsync(
+		"get_product_inventory",
+		new Dictionary<string, object?> { ["productName"] = "Camping Tent" });
+	var inventoryContent = GetStructuredContent(inventory, "get_product_inventory");
+	Assert(inventoryContent.GetProperty("found").GetBoolean(), "Known product was not found.");
+	Assert(
+		inventoryContent.GetProperty("details").GetProperty("inStock").GetInt32() == 15,
+		"Known product returned the wrong inventory.");
+
+	var missingOrder = await client.CallToolAsync(
+		"get_order_details",
+		new Dictionary<string, object?> { ["orderId"] = "99999" });
+	var missingContent = GetStructuredContent(missingOrder, "get_order_details");
+	Assert(!missingContent.GetProperty("found").GetBoolean(), "Unknown order was reported as found.");
+	Assert(
+		!missingContent.TryGetProperty("order", out var missingOrderData) ||
+			missingOrderData.ValueKind == JsonValueKind.Null,
+		"Unknown order included order data.");
+}
+
+static async Task<McpClient> CreateClientAsync(string repositoryRoot, string projectPath)
+{
+	var environmentVariables = StdioClientTransportOptions.GetDefaultEnvironmentVariables();
+	AddEnvironmentVariable(environmentVariables, "DOTNET_ROOT");
+	AddEnvironmentVariable(environmentVariables, "NUGET_PACKAGES");
+
+	var transport = new StdioClientTransport(new StdioClientTransportOptions
+	{
+		Name = Path.GetFileNameWithoutExtension(projectPath),
+		Command = "dotnet",
+		Arguments = [
+			"run",
+			"--project",
+			Path.Combine(repositoryRoot, projectPath),
+			"--configuration",
+			"Release",
+			"--no-build"
+		],
+		WorkingDirectory = repositoryRoot,
+		InheritEnvironmentVariables = false,
+		EnvironmentVariables = environmentVariables,
+		ShutdownTimeout = TimeSpan.FromSeconds(10)
+	});
+
+	return await McpClient.CreateAsync(transport);
+}
+
+static void AssertToolSchema(
+	IList<McpClientTool> tools,
+	string toolName,
+	string? requiredInput,
+	string expectedOutputType,
+	params string[] requiredOutputProperties)
+{
+	var tool = tools.SingleOrDefault(tool => tool.Name == toolName)
+		?? throw new InvalidOperationException($"Tool '{toolName}' was not discovered.");
+
+	var inputSchema = tool.ProtocolTool.InputSchema;
+	Assert(inputSchema.GetProperty("type").GetString() == "object", $"Tool '{toolName}' has an invalid input schema.");
+	if (requiredInput is not null)
+	{
+		Assert(
+			inputSchema.GetProperty("required").EnumerateArray().Any(item => item.GetString() == requiredInput),
+			$"Tool '{toolName}' does not require '{requiredInput}'.");
+	}
+
+	var outputSchema = tool.ProtocolTool.OutputSchema
+		?? throw new InvalidOperationException($"Tool '{toolName}' does not advertise an output schema.");
+	Assert(
+		outputSchema.GetProperty("type").GetString() == expectedOutputType,
+		$"Tool '{toolName}' output schema is not '{expectedOutputType}'.");
+
+	if (requiredOutputProperties.Length > 0)
+	{
+		var required = outputSchema.GetProperty("required");
+		var properties = outputSchema.GetProperty("properties");
+		foreach (var propertyName in requiredOutputProperties)
+		{
+			Assert(properties.TryGetProperty(propertyName, out _), $"Tool '{toolName}' has no '{propertyName}' output.");
+			Assert(
+				required.EnumerateArray().Any(item => item.GetString() == propertyName),
+				$"Tool '{toolName}' does not require its '{propertyName}' output.");
+		}
+	}
+}
+
+static JsonElement GetStructuredContent(CallToolResult result, string toolName)
+{
+	Assert(result.IsError is not true, $"Tool '{toolName}' returned an error.");
+	return result.StructuredContent
+		?? throw new InvalidOperationException($"Tool '{toolName}' did not return structured content.");
+}
+
+static void AddEnvironmentVariable(Dictionary<string, string?> environmentVariables, string name)
+{
+	if (Environment.GetEnvironmentVariable(name) is { } value)
+	{
+		environmentVariables[name] = value;
+	}
+}
+
+static string FindRepositoryRoot()
+{
+	for (var directory = new DirectoryInfo(Directory.GetCurrentDirectory());
+		 directory is not null;
+		 directory = directory.Parent)
+	{
+		if (Directory.Exists(Path.Combine(directory.FullName, "Part 05 - MCP Server Basics")) &&
+			Directory.Exists(Path.Combine(directory.FullName, "Part 06 - Enhanced MCP Server")))
+		{
+			return directory.FullName;
+		}
+	}
+
+	throw new InvalidOperationException("Run this validation from inside the ai-workshop repository.");
+}
+
+static void Assert(bool condition, string message)
+{
+	if (!condition)
+	{
+		throw new InvalidOperationException(message);
+	}
+}


### PR DESCRIPTION
## Summary

- return typed records from the Part 5 weather tools and Part 6 business tools with `UseStructuredContent = true`
- preserve direct scalar structured content for the random-number tool without assuming a legacy `{ "result": ... }` wrapper
- add a deterministic stdio client harness that validates schemas and all existing tool scenarios, and run it in CI
- align attendee guidance and record explicit MCP SDK 2.x adopt/defer decisions in the instructor guide

## MCP SDK 2.x decisions

Typed structured output is adopted. Streamable HTTP, multi-round-trip elicitation, standard HTTP headers, caching hints, MCP Apps, and Tasks are deferred because they add prerequisites or workflows that do not fit these samples. Deprecated roots, sampling, protocol logging, and legacy SSE are not taught as modern defaults.

## Validation

- .NET 10.0.400 Release builds for Parts 5 and 6: zero warnings
- structured-output protocol harness: passed
- NuGet vulnerability checks: no vulnerable packages
- NuGet packaging for Parts 5 and 6: passed
- Markdown lint and changed-file link checks: passed
- `git diff --check`: passed

Fixes #617