### PR TITLE
Add workshop issue template and enhance instructor notes for Azure AI Search provisioning

### DIFF
--- a/.github/ISSUE_TEMPLATE/workshop-issue.yml
+++ b/.github/ISSUE_TEMPLATE/workshop-issue.yml
@@ -1,0 +1,117 @@
+name: Workshop issue
+description: Report a workshop defect, documentation problem, dependency concern, or enhancement
+title: ""
+labels:
+  - needs-decision
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the workshop. New issues start with the
+        `needs-decision` label. During triage, maintainers replace it with one
+        priority label (`P0` through `P3`) and apply the appropriate type label.
+
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue type
+      description: Select the existing repository label that best describes this issue.
+      options:
+        - bug
+        - documentation
+        - dependencies
+        - enhancement
+    validations:
+      required: true
+
+  - type: dropdown
+    id: requested-priority
+    attributes:
+      label: Requested priority
+      description: Maintainers confirm or change this during triage.
+      options:
+        - P0 - Core supported path is broken; fix immediately
+        - P1 - Attendees cannot complete a required exercise correctly
+        - P2 - A workaround exists, an optional path is broken, or significant drift exists
+        - P3 - Polish, minor documentation, screenshots, or future improvement
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Workshop area
+      options:
+        - General or multiple parts
+        - Part 1 - Setup
+        - Part 2 - Build Chat App
+        - Part 3 - Add RAG
+        - Part 4 - AI Web Chat Template
+        - Part 5 - MCP Server Basics
+        - Part 6 - Enhanced MCP Server
+        - Part 7 - MCP Publishing
+        - Part 8 - Agent Framework Basics
+        - Part 9 - Adding AI to an Existing App
+        - Part 10 - Choosing Providers and Services
+        - Part 11 - Deployment
+        - Instructor documentation
+        - CI or repository infrastructure
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the problem or proposed improvement concisely.
+      placeholder: What should maintainers know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: attendee-impact
+    attributes:
+      label: Attendee or instructor impact
+      description: Explain who is affected and whether a workaround exists.
+      placeholder: Which workshop path is affected, and what happens?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction or proposed change
+      description: Provide exact steps for a defect or a concrete scope for an enhancement.
+      placeholder: |
+        1. Start from...
+        2. Run...
+        3. Observe...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected outcome
+      description: Describe the correct behavior or documentation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation
+      description: List the builds, tests, attendee flows, or documentation checks that should pass.
+      placeholder: |
+        - [ ] Release build completes with zero warnings
+        - [ ] Attendee steps reproduce the committed snapshot
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies and related issues
+      description: Link related issues, pull requests, external dependencies, or blockers.
+      placeholder: "Related to #123"

--- a/docs/instructor/AICHATWEB_TEMPLATE_NOTES.md
+++ b/docs/instructor/AICHATWEB_TEMPLATE_NOTES.md
@@ -107,12 +107,30 @@ Two consequences for the room:
 - **`azd` deploys markitdown too.** It becomes a third container app alongside the
   web app and Qdrant.
 
+## Azure AI Search provisioning can return an opaque conflict
+
+When creating a Search service manually for workshop preparation, Azure may fail
+with `409 Conflict`, an `Unknown` error code, and only "An internal error has
+occurred." The deployment operation, provider registration, regional SKU quota,
+and name-availability check can all look valid.
+
+Before changing regions or opening a support request, retry with a globally
+distinctive service name such as `<event>-<owner>-search`. A September 2026 test
+failed with the generic-looking `azure-ai-search` name even though Azure's
+name-availability check returned `true`, then succeeded immediately with
+`azure-ai-search-workshop-jongalloway`.
+
+This applies to manual instructor setup. Part 11 normally lets Aspire and `azd`
+generate the Search infrastructure and should not require attendees to choose a
+service name.
+
 ## Things that go wrong in the room
 
 | Symptom | Cause |
 | --- | --- |
 | Dashboard shows an "Azure provisioning" banner and resources stay in Starting | `AddAzureOpenAI` still in `AppHost.cs`; the swap to `AddConnectionString` was missed |
 | 404 or "deployment not found" on the first chat message | `AddChatClient` still says `gpt-4o-mini` |
+| Manual Search creation fails with `409 Conflict` and `Unknown` | Retry with a globally distinctive service name before changing regions |
 | First question hangs for a minute | Expected — lazy ingestion, including the PDF round-trip through markitdown |
 | Qdrant or markitdown never start | Docker Desktop isn't running |
 | `NU1903` on restore | Package bump step skipped |


### PR DESCRIPTION
This pull request introduces a new issue template for workshop-related reports and improves instructor documentation with guidance on Azure AI Search provisioning errors.

**Issue tracking improvements:**
* Added a new `.github/ISSUE_TEMPLATE/workshop-issue.yml` file to standardize workshop issue reporting, including required fields for issue type, priority, affected area, and detailed reproduction steps.

**Instructor documentation updates:**
* Updated `docs/instructor/AICHATWEB_TEMPLATE_NOTES.md` to document the potential for opaque `409 Conflict` errors when manually provisioning Azure AI Search resources, including a recommended workaround to use a globally distinctive service name. Also updated troubleshooting tables to reference this issue and solution.