### PR TITLE
Fix stale Qdrant guidance in workshop docs

### DIFF
--- a/Part 04 - AI Web Chat Template/README.md
+++ b/Part 04 - AI Web Chat Template/README.md
@@ -131,14 +131,14 @@ dotnet add GenAiLab.AppHost package Aspire.Hosting.AppHost --version 13.5.3
 dotnet add GenAiLab.AppHost package Aspire.Hosting.Qdrant --version 13.5.3
 dotnet add GenAiLab.Web package Aspire.Qdrant.Client --version 13.5.3
 dotnet add GenAiLab.Web package Aspire.Azure.AI.OpenAI --prerelease
+dotnet add GenAiLab.Web package CommunityToolkit.VectorData.Qdrant --version 1.0.0
 dotnet add GenAiLab.Web package Microsoft.Extensions.AI
 dotnet add GenAiLab.Web package Microsoft.Extensions.AI.OpenAI
-dotnet add GenAiLab.Web package Microsoft.SemanticKernel.Connectors.Qdrant --prerelease
 ```
 
-`Aspire.Azure.AI.OpenAI` and `Microsoft.SemanticKernel.Connectors.Qdrant` need
-`--prerelease` because neither has ever shipped a stable build; without the flag
-the command fails.
+`Aspire.Azure.AI.OpenAI` is still preview, so it needs `--prerelease`. The
+current template emits `CommunityToolkit.VectorData.Qdrant` as its Qdrant
+connector, so do not install a second Qdrant package alongside it.
 
 > [!NOTE]
 > The completed solution in this repo pins exact versions, so if a newer release

--- a/Part 10 - Choosing Providers and Services/README.md
+++ b/Part 10 - Choosing Providers and Services/README.md
@@ -206,7 +206,7 @@ dotnet remove GenAiLab.AppHost package Aspire.Hosting.Qdrant
 dotnet add GenAiLab.AppHost package Aspire.Hosting.Azure.Search --version 13.5.3
 
 dotnet remove GenAiLab.Web package Aspire.Qdrant.Client
-dotnet remove GenAiLab.Web package Microsoft.SemanticKernel.Connectors.Qdrant
+dotnet remove GenAiLab.Web package CommunityToolkit.VectorData.Qdrant
 dotnet add GenAiLab.Web package Aspire.Azure.Search.Documents --version 13.5.3
 dotnet add GenAiLab.Web package CommunityToolkit.VectorData.AzureAISearch --version 1.0.0
 ```

--- a/docs/instructor/AICHATWEB_TEMPLATE_NOTES.md
+++ b/docs/instructor/AICHATWEB_TEMPLATE_NOTES.md
@@ -7,8 +7,9 @@ and what to say when someone asks.
 Verified against `Microsoft.Extensions.AI.Templates` **10.10.0** on .NET SDK
 11.0.100-preview.7.26381.103, September 2026.
 
-The current scaffold for `--vector-store qdrant --aspire` emits the Qdrant
-packages `Aspire.Qdrant.Client` and `CommunityToolkit.VectorData.Qdrant`.
+A fresh 10.10.0 scaffold for `--vector-store qdrant --aspire` emits the Qdrant
+packages `Aspire.Qdrant.Client` and `CommunityToolkit.VectorData.Qdrant`; this is
+the package baseline used by Parts 4 and 10.
 `Microsoft.SemanticKernel.Connectors.Qdrant` is stale for this template and
 should not be added alongside the CommunityToolkit connector because it creates a
 second Qdrant registration path.

--- a/docs/instructor/AICHATWEB_TEMPLATE_NOTES.md
+++ b/docs/instructor/AICHATWEB_TEMPLATE_NOTES.md
@@ -4,8 +4,14 @@ Instructor-facing background for Parts 4 and 11. Attendees don't need any of thi
 but it explains why the workshop deviates from the template in a couple of places
 and what to say when someone asks.
 
-Verified against `Microsoft.Extensions.AI.Templates` **10.7.0-preview.3.26309.5**
-on .NET SDK 10.0.301, July 2026.
+Verified against `Microsoft.Extensions.AI.Templates` **10.10.0** on .NET SDK
+11.0.100-preview.7.26381.103, September 2026.
+
+The current scaffold for `--vector-store qdrant --aspire` emits the Qdrant
+packages `Aspire.Qdrant.Client` and `CommunityToolkit.VectorData.Qdrant`.
+`Microsoft.SemanticKernel.Connectors.Qdrant` is stale for this template and
+should not be added alongside the CommunityToolkit connector because it creates a
+second Qdrant registration path.
 
 ## Azure provisioning is the one real deviation
 


### PR DESCRIPTION
Fixes: #632

The template-generated AI Web Chat app now emits `CommunityToolkit.VectorData.Qdrant`, but the workshop docs still told attendees to add the stale Semantic Kernel connector. That created duplicate Qdrant registrations and build issues in the Part 4 and Part 10 steps.

This change keeps the Part 4 package list aligned with the current template and updates the Part 10 Azure AI Search migration to remove the actual Qdrant package the template installs. I also validated the migration flow in a fresh scaffold; the resulting app builds cleanly.

## What changed

- Updated Part 4 to keep the current `CommunityToolkit.VectorData.Qdrant` package and avoid adding a second Qdrant connector.
- Updated Part 10 to remove `CommunityToolkit.VectorData.Qdrant` during the Azure AI Search migration.
- Kept the Azure AI Search package flow aligned with the current production recommendation.

## Validation

- Verified the corrected flow against a fresh scaffold.
- Confirmed the resulting app builds successfully with 0 errors in the migration path.