### PR TITLE
Fix Part 9 Discovery page lab instructions

### DIFF
--- a/Part 09 - Adding AI to an Existing App/README.md
+++ b/Part 09 - Adding AI to an Existing App/README.md
@@ -78,7 +78,7 @@ dotnet run --project eShopLite.AppHost
 
 The Aspire dashboard opens. Click through to the **store** endpoint, then go to **Products** and search.
 
-Search for `water`. You get the Insulated Water Bottle, because the word "water" is in the row.
+Search for `water`. You get three matches: the Outdoor Rain Jacket, the Insulated Water Bottle, and the Daypack, because the seeded descriptions include words such as "waterproof" and other `water` substrings.
 
 Now search for `warm at night`. You get **nothing**.
 
@@ -304,7 +304,8 @@ group.MapGet("/aisearch/{search}", async (
 
     // Preserve the ranking the vector search gave us.
     var ordered = ids
-        .Select(id => products.First(p => p.Id == id))
+        .Select(id => products.FirstOrDefault(p => p.Id == id))
+        .OfType<Product>()
         .ToList();
 
     return Results.Ok(ordered);
@@ -312,7 +313,7 @@ group.MapGet("/aisearch/{search}", async (
     .WithName("AiSearchProducts");
 ```
 
-The reordering step is easy to miss. `WHERE Id IN (...)` returns rows in whatever order the database likes, which throws away the ranking you just paid an embedding model to compute.
+The reordering step is easy to miss. `WHERE Id IN (...)` returns rows in whatever order the database likes, which throws away the ranking you just paid an embedding model to compute. `FirstOrDefault(...).OfType<Product>()` also skips stale vector IDs when a product row has disappeared from the relational table, instead of throwing `InvalidOperationException`.
 
 ### 1.7 Try it
 
@@ -488,29 +489,93 @@ builder.Services.AddScoped<ProductDiscovery>();
 
 ### 2.4 Add the page
 
-Create `Store/Components/Pages/Discovery.razor`. The full file is in `eShopLite/`; the parts that matter:
+Create `Store/Components/Pages/Discovery.razor`:
 
 ```razor
 @page "/discovery"
 @using DataEntities
 @using Store.Ai
 @inject ProductDiscovery Assistant
-```
 
-> Inject it as `Assistant`, not `Discovery`. Blazor generates a class named after the file, so `@inject ProductDiscovery Discovery` produces a member with the same name as its enclosing type and the compiler rejects it with CS0542.
+<PageTitle>Ask</PageTitle>
 
-```razor
-@if (result is not null)
+<h1>Ask</h1>
+
+<p>Describe what you need in your own words. Try "something to keep me warm at night".</p>
+
+<div class="row mb-4">
+    <div class="col-md-8">
+        <div class="input-group">
+            <input @bind="question" @bind:event="oninput" @onkeyup="HandleKeyUp"
+                   class="form-control" placeholder="What are you looking for?"
+                   aria-label="What are you looking for?" disabled="@busy" />
+            <button class="btn btn-primary" @onclick="Ask" disabled="@busy">Ask</button>
+        </div>
+    </div>
+</div>
+
+@if (busy)
+{
+    <p><em>Thinking...</em></p>
+}
+else if (result is not null)
 {
     <div class="alert alert-info">@result.Answer</div>
 
     @if (result.Products.Count > 0)
     {
         <h2 class="h5">Products used to answer</h2>
-        @* card for each product in result.Products *@
+        <div class="row">
+            @foreach (var product in result.Products)
+            {
+                <div class="col-md-4 mb-4">
+                    <div class="card h-100">
+                        <div class="card-body">
+                            <h5 class="card-title">@product.Name</h5>
+                            <p class="card-text">@product.Description</p>
+                            <p class="card-text"><strong>@product.Price.ToString("C")</strong></p>
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+}
+
+@code {
+    private string question = string.Empty;
+    private DiscoveryResult? result;
+    private bool busy;
+
+    private async Task Ask()
+    {
+        if (string.IsNullOrWhiteSpace(question))
+        {
+            return;
+        }
+
+        busy = true;
+        try
+        {
+            result = await Assistant.AskAsync(question);
+        }
+        finally
+        {
+            busy = false;
+        }
+    }
+
+    private async Task HandleKeyUp(KeyboardEventArgs args)
+    {
+        if (args.Key == "Enter")
+        {
+            await Ask();
+        }
     }
 }
 ```
+
+> Inject it as `Assistant`, not `Discovery`. Blazor generates a class named after the file, so `@inject ProductDiscovery Discovery` produces a member with the same name as its enclosing type and the compiler rejects it with CS0542.
 
 Showing the products the answer was built from is not decoration. It is how a shopper checks the assistant, and how you notice when retrieval is the thing that went wrong rather than the model.
 


### PR DESCRIPTION
This change makes the Part 9 lab self-contained and aligned with the completed eShopLite answer key. The README previously left attendees with a partial `Discovery.razor` fragment and diverged from the working implementation in a couple of key details that would cause confusion while following the steps in order.

The lab now includes the complete `Discovery.razor` page, including the input form, busy state, Enter-key handling, and product cards, while keeping the `Assistant` injection warning that avoids the Blazor naming collision. I also updated the stale-vector example to skip missing relational rows defensively, and corrected the baseline `water` search description so it matches the seeded catalog behavior.

Validation:
- `markdownlint` on the updated README
- `dotnet build` of the Part 9 `eShopLite` solution in Release with zero warnings

Fixes: #633