### PR TITLE
Reconcile unversioned AI package commands with committed snapshots (#636)

### DIFF
--- a/Part 02 - Build Chat App/ChatApp/ChatApp.csproj
+++ b/Part 02 - Build Chat App/ChatApp/ChatApp.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.9.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.9.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.10.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.10.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.12" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.12" />
   </ItemGroup>

--- a/Part 02 - Build Chat App/README.md
+++ b/Part 02 - Build Chat App/README.md
@@ -61,6 +61,11 @@ dotnet add package Microsoft.Extensions.Configuration.UserSecrets
 dotnet add package Microsoft.Extensions.Logging.Console
 ```
 
+These commands intentionally use the latest compatible package versions. The
+committed snapshot records the versions that were validated for this workshop;
+do not add older version pins unless the lab calls for an explicit
+compatibility or security override.
+
 ### Option B: Add packages in Visual Studio 2026
 
 1. In Solution Explorer, right-click the `ChatApp` project and select

--- a/Part 03 - Add RAG/README.md
+++ b/Part 03 - Add RAG/README.md
@@ -329,6 +329,10 @@ dotnet add package Microsoft.Bcl.Memory --version 10.0.12
 dotnet add package SQLitePCLRaw.bundle_e_sqlite3 --version 3.0.5
 ```
 
+The AI and MEDI commands use the latest compatible releases. Keep the explicit
+versions for `Microsoft.Bcl.Memory` and `SQLitePCLRaw.bundle_e_sqlite3`: they
+are security overrides required by the validated vector-store dependency graph.
+
 #### Option B: Add packages in Visual Studio 2026
 
 1. In Solution Explorer, right-click the console project and select

--- a/Part 03 - Add RAG/RagChatApp/RagChatApp.csproj
+++ b/Part 03 - Add RAG/RagChatApp/RagChatApp.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.9.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.9.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.10.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.10.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.12" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.12" />
   </ItemGroup>

--- a/Part 03 - Add RAG/checkpoints/verify/ManualCheckpoint/ManualCheckpoint.csproj
+++ b/Part 03 - Add RAG/checkpoints/verify/ManualCheckpoint/ManualCheckpoint.csproj
@@ -25,8 +25,8 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.9.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.9.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.10.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.10.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.12" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.12" />
   </ItemGroup>

--- a/Part 03 - Add RAG/checkpoints/verify/MediCheckpoint/MediCheckpoint.csproj
+++ b/Part 03 - Add RAG/checkpoints/verify/MediCheckpoint/MediCheckpoint.csproj
@@ -26,11 +26,11 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.9.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.9.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.10.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.10.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.12" />
-    <PackageReference Include="Microsoft.Extensions.DataIngestion" Version="10.8.0-preview.1.26364.2" />
-    <PackageReference Include="Microsoft.Extensions.DataIngestion.Markdig" Version="10.8.0-preview.1.26364.2" />
+    <PackageReference Include="Microsoft.Extensions.DataIngestion" Version="10.10.0-preview.1.26459.2" />
+    <PackageReference Include="Microsoft.Extensions.DataIngestion.Markdig" Version="10.10.0-preview.1.26459.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.12" />
     <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="2.0.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.SqliteVec" Version="1.74.0-preview" />

--- a/Part 08 - Agent Framework Basics/AgentApp/AgentApp.csproj
+++ b/Part 08 - Agent Framework Basics/AgentApp/AgentApp.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Agents.AI" Version="1.20.0" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.9.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.9.0" />
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.10.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.10.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.12" />
   </ItemGroup>
 

--- a/Part 08 - Agent Framework Basics/README.md
+++ b/Part 08 - Agent Framework Basics/README.md
@@ -208,7 +208,8 @@ dotnet user-secrets init
 
 These commands intentionally use the latest compatible AI and Agent Framework
 packages. The committed snapshot records the versions validated with this
-workshop; keep any explicit protocol or security pins shown in later steps.
+workshop; if you try the optional MCP client excerpt above, keep its explicit
+`ModelContextProtocol.Core` package version.
 
 #### Option B: Visual Studio 2026
 

--- a/Part 08 - Agent Framework Basics/README.md
+++ b/Part 08 - Agent Framework Basics/README.md
@@ -206,6 +206,10 @@ dotnet add package Microsoft.Extensions.Configuration.UserSecrets
 dotnet user-secrets init
 ```
 
+These commands intentionally use the latest compatible AI and Agent Framework
+packages. The committed snapshot records the versions validated with this
+workshop; keep any explicit protocol or security pins shown in later steps.
+
 #### Option B: Visual Studio 2026
 
 1. Select **File > New > Project**, search for **Console App**, and select **Next**.

--- a/Part 09 - Adding AI to an Existing App/README.md
+++ b/Part 09 - Adding AI to an Existing App/README.md
@@ -102,6 +102,11 @@ dotnet add package Microsoft.Extensions.AI.OpenAI
 dotnet add package Microsoft.SemanticKernel.Connectors.SqliteVec --prerelease
 ```
 
+The AI package commands use the latest compatible releases. Leave the
+project's explicit `SQLitePCLRaw.bundle_e_sqlite3` and `Microsoft.OpenApi`
+references in place; they are documented security and compatibility overrides,
+not AI package choices.
+
 `SqliteVec` gives you a vector store in a local file. No container, no service to run.
 
 > The project already pins `SQLitePCLRaw.bundle_e_sqlite3` 3.0.5 and `Microsoft.OpenApi` 2.12.2. Both are there to pull transitive dependencies above versions with open advisories, and neither has anything to do with AI. Leave them alone.

--- a/Part 09 - Adding AI to an Existing App/eShopLite/Products/Products.csproj
+++ b/Part 09 - Adding AI to an Existing App/eShopLite/Products/Products.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.12" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.12" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.9.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.9.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.10.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.10.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.12.2" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.SqliteVec" Version="1.74.0-preview" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />

--- a/Part 09 - Adding AI to an Existing App/eShopLite/Store/Store.csproj
+++ b/Part 09 - Adding AI to an Existing App/eShopLite/Store/Store.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.9.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.9.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.10.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.10.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary

Closes #636.

Reconciles unversioned AI package commands in workshop READMEs with committed answer snapshots using the latest compatible package versions:
- Updated `Microsoft.Extensions.AI` and `Microsoft.Extensions.AI.OpenAI` from 10.9.0 to 10.10.0 across Parts 2, 3, 8, and 9 snapshots.
- Updated `Microsoft.Agents.AI` from 1.20.0 to 1.21.0 in the Part 8 snapshot.
- Updated `Microsoft.Extensions.DataIngestion` and `Microsoft.Extensions.DataIngestion.Markdig` from 10.8.0-preview.1.26364.2 to 10.10.0-preview.1.26459.2 in Part 3 verification checkpoints.
- Added explanatory notes to README files regarding unversioned package commands and preserved security/compatibility overrides (`SQLitePCLRaw.bundle_e_sqlite3`, `Microsoft.Bcl.Memory`, `Microsoft.SemanticKernel.Connectors.SqliteVec`, and `Microsoft.OpenApi`).

## Validation
- Restored and built all affected projects in Release with `-warnaserror` (0 warnings, 0 errors).
- Vulnerability scans with `dotnet list package --vulnerable --include-transitive` reported no known vulnerabilities across all affected projects.
- Markdown linting and link checks passed.