### PR TITLE
Fix stale Foundry Local CLI steps in Part 9

### DIFF
--- a/Part 09 - Adding AI to an Existing App/README.md
+++ b/Part 09 - Adding AI to an Existing App/README.md
@@ -631,6 +631,8 @@ winget install Microsoft.FoundryLocal
 foundry run qwen2.5-1.5b
 ```
 
+This opens an interactive local model session. Leave it running in one terminal window, then open a second terminal to run `foundry server status` and the `curl`/`dotnet user-secrets` commands below. When you are done, press `Ctrl+C` in the first terminal to stop the model.
+
 Any small **instruct** model will do. Prefer the generic model id such as `qwen2.5-1.5b` and let Foundry Local choose the correct local variant rather than pinning an NPU-only id.
 
 Then find the endpoint and the exact model id it is serving:

--- a/Part 09 - Adding AI to an Existing App/README.md
+++ b/Part 09 - Adding AI to an Existing App/README.md
@@ -624,19 +624,19 @@ Create `Store/Ai/SearchTelemetry.cs` — a capped in-memory queue of `SearchEven
 
 ### 3.2 Point an IChatClient at a local model
 
-Install [Foundry Local](https://learn.microsoft.com/azure/ai-foundry/foundry-local/get-started) and start a model:
+Install [Foundry Local](https://learn.microsoft.com/azure/ai-foundry/foundry-local/get-started) and start a small instruct model:
 
 ```bash
 winget install Microsoft.FoundryLocal
-foundry model run qwen2.5-1.5b-instruct-openvino-npu:5
+foundry run qwen2.5-1.5b
 ```
 
-Any small model will do. Pick an **instruct** model rather than a reasoning one — see the notes at the end of this step for why.
+Any small **instruct** model will do. Prefer the generic model id such as `qwen2.5-1.5b` and let Foundry Local choose the correct local variant rather than pinning an NPU-only id.
 
 Then find the endpoint and the exact model id it is serving:
 
 ```bash
-foundry service status
+foundry server status
 curl http://127.0.0.1:PORT/v1/models
 ```
 
@@ -647,7 +647,9 @@ dotnet user-secrets set "LocalModel:Endpoint" "http://127.0.0.1:PORT/v1"
 dotnet user-secrets set "LocalModel:Model" "THE-ID-FROM-/v1/models"
 ```
 
-> Two things that will cost you ten minutes if you guess. The endpoint must be the OpenAI-compatible base ending in `/v1` — the SDK appends `/chat/completions` to it. And the model id must be the one `/v1/models` reports, not the friendly alias; a model you have not downloaded returns `400`.
+> [!WARNING]
+> The first request can take minutes to load the model into memory. Warm it with a throwaway prompt before the demo, or the audience will sit through a long silence. The port reported by `foundry server status` can change after a restart, so re-run the secret setup after rebooting. And the model id must be the exact value from `/v1/models`, not the friendly alias; a model you have not downloaded returns `400`.
+> The endpoint must be the OpenAI-compatible base ending in `/v1` — the SDK appends `/chat/completions` to it.
 
 Foundry Local speaks the OpenAI protocol, so it needs no new package — the same `OpenAIClient` you already have, pointed somewhere else:
 


### PR DESCRIPTION
This fixes the Part 9 local-model instructions for the current Foundry Local CLI. The old commands and model pin were stale, which could leave attendees with a failed startup or a model that does not match their hardware.

The update switches the walkthrough to the current command names (`foundry run ...` and `foundry server status`), recommends a generic small instruct model instead of the NPU-only id, and adds a stronger warning about warm-up time, port changes after a restart, and the requirement to use the exact model id reported by `/v1/models`.

Fixes: #574